### PR TITLE
 Add unit rendering to PDF/print outputs for number/text fields

### DIFF
--- a/src/Home/Script/Screen/_TypeForm/Repeatable.tsx
+++ b/src/Home/Script/Screen/_TypeForm/Repeatable.tsx
@@ -206,6 +206,7 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
                     printable: field.printable,
                     label: field.label,
                     prePopulate: field.prePopulate,
+                    unit: field.unit,
                 };
                 const shouldLogField = ['date', 'datetime', 'period'].includes(field.type);
                 if (shouldLogField) {
@@ -433,6 +434,7 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
             const base = {
                 'label': field?.label,
                 'exportType': field?.type,
+                'unit': field?.unit,
                 ...valueObj,
             };
 

--- a/src/Home/Script/Screen/_TypeForm/index.tsx
+++ b/src/Home/Script/Screen/_TypeForm/index.tsx
@@ -97,6 +97,7 @@ export function TypeForm({ }: TypeFormProps) {
                 value2,
                 valueText,
                 label: f.label,
+                unit: f.unit,
                 key: f.key,
                 type: f.type,
                 dataType: f.dataType,

--- a/src/Home/Sessions/Session.tsx
+++ b/src/Home/Sessions/Session.tsx
@@ -20,6 +20,8 @@ export function Session({ session, onBack }: SessionProps) {
         onBack();
     };
 
+    console.log('Rendering Session for session:', JSON.stringify(session));
+
     return (
         <Modal
             visible

--- a/src/components/Session/formToHTML/index.ts
+++ b/src/components/Session/formToHTML/index.ts
@@ -2,6 +2,7 @@
 
 import QRCode from 'qrcode';
 import { ScreenEntryValue } from '@/src/types';
+import { formatValueWithUnit } from '@/src/utils/units';
 import baseHTML from './baseHTML';
 import groupEntries from './groupEntries';
 import { reportErrors } from '../../../data/api';
@@ -165,9 +166,13 @@ export default async (session: any, showConfidential?: boolean) => {
                   }) as typeof extraLabels;
                 }
                 let value = v.valueText || v.value || 'N/A'
-                const exportType = v.type ||v.exportType
+                const exportType = v.type || v.exportType
                 if (exportType == 'datetime' || exportType == 'date') {
                   value = formatDate(value, exportType)
+                }
+                const shouldAppendUnit = exportType === 'number' || exportType === 'text'
+                if (shouldAppendUnit && !Array.isArray(value)) {
+                  value = formatValueWithUnit(value, v.unit)
                 }
 
                 return `

--- a/src/components/Session/printSectionsToHTML/index.ts
+++ b/src/components/Session/printSectionsToHTML/index.ts
@@ -1,5 +1,6 @@
 import QRCode from 'qrcode';
 import { ScreenEntryValue } from '@/src/types';
+import { formatValueWithUnit } from '@/src/utils/units';
 import { getBaseHTML } from "./baseHTML";
 import { toHL7Like } from '../../../data/hl7Like'
 import { formatExportableSession } from '../../../data/getConvertedSession'
@@ -156,8 +157,13 @@ export async function printSectionsToHTML({
             }
             
             let value: any = v.valueText || v.value || 'N/A'
-            if(v.type === 'datetime' || v.type === 'date'){
-              value = formatDate(value, v.type)
+            const exportType = v.type || v.exportType
+            if (exportType === 'datetime' || exportType === 'date') {
+              value = formatDate(value, exportType)
+            }
+            const shouldAppendUnit = exportType === 'number' || exportType === 'text'
+            if (shouldAppendUnit && !Array.isArray(value)) {
+              value = formatValueWithUnit(value, v.unit)
             }
 
             return `
@@ -208,8 +214,13 @@ export async function printSectionsToHTML({
                     value = `<i><strong>${value}</strong></i>`
                   } 
 
-                  if(v.exportType === 'datetime' || v.exportType === 'date'){
-                    value = formatDate(value, v.exportType)
+                  const exportType = v.exportType || v.type
+                  if (exportType === 'datetime' || exportType === 'date') {
+                    value = formatDate(value, exportType)
+                  }
+                  const shouldAppendUnit = exportType === 'number' || exportType === 'text'
+                  if (shouldAppendUnit) {
+                    value = formatValueWithUnit(value, v.unit)
                   }
                   
                   return `

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,7 @@ export type ScreenEntryValue = {
   key2?: any;
   valueText?: any;
   valueLabel?: any;
+  unit?: string;
   label?: string;
   key?: string;
   parentKey?: string;

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,0 +1,16 @@
+const normalize = (value?: string | number | null) => `${value ?? ""}`.trim()
+
+export function formatValueWithUnit(value: string | number | null | undefined, unit?: string | null): string {
+  const normalizedValue = normalize(value)
+  const normalizedUnit = normalize(unit)
+  if (!normalizedValue || !normalizedUnit || normalizedValue === "N/A") return normalizedValue
+
+  const lowerValue = normalizedValue.toLowerCase()
+  const lowerUnit = normalizedUnit.toLowerCase()
+
+  if (lowerValue.endsWith(` ${lowerUnit}`) || lowerValue.endsWith(`(${lowerUnit})`)) {
+    return normalizedValue
+  }
+
+  return `${normalizedValue} ${normalizedUnit}`
+}


### PR DESCRIPTION
# Ticket [NEOAPP-1211](https://neotree.atlassian.net/browse/NEOAPP-1211)

Implements support for displaying a field’s unit of measurement in PDF preview and printed outputs, ensuring clinical values remain clear and unambiguous.

Some numeric or text inputs capture measurements (e.g., cm, kg, mmHg), but these units were not previously shown in generated PDFs. This enhancement improves clarity for clinicians and aligns printed outputs with what is captured in scripts.

Key Changes

Carried the unit attribute through entry values, including inside repeatable groups.

Updated print output generators:

formToHTML

printSectionsToHTML

Introduced and applied formatValueWithUnit for number/text fields in print contexts.

Ensures units appear only in PDF/print views not within the in-app UI.