### PR TITLE
Datakey for compiled diagnosis list in admission scripts

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
     "expo": {
         "name": "NeoTree",
         "slug": "neotree",
-        "version": "2.5.24",
+        "version": "2.5.25",
         "orientation": "portrait",
         "icon": "./assets/images/icon.png",
         "scheme": "myapp",

--- a/src/Home/Script/Screen/Diagnosis/discharge-diagnoses.tsx
+++ b/src/Home/Script/Screen/Diagnosis/discharge-diagnoses.tsx
@@ -84,6 +84,8 @@ export function DischargeDiagnoses({ getDefaultDiagnosis }: SortPriorityProps) {
             renderItem={({ item }) => {
                 const [d] = Object.values(item);
 
+                if (d.hcw_agree !== 'Yes') return null;
+
                 return (
                     <Content>
                         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
@@ -91,14 +93,12 @@ export function DischargeDiagnoses({ getDefaultDiagnosis }: SortPriorityProps) {
                                 <Text>{d.diagnosis}</Text>
                                 <Text variant="caption" style={{ color: '#999' }}>{d.Suggested ? 'Suggested' : 'Selected by HCW'}</Text>
                             </View>
-                            {!!d.Suggested && (
-                                <View>
-                                    <Text 
-                                        variant="caption" 
-                                        style={{ color: d.hcw_agree === 'Yes' ? '#16a085' : '#e74c3c' }}
-                                    >{d.hcw_agree === 'Yes' ? 'HCW agreed' : 'HCW disagreed'}</Text>
-                                </View>
-                            )}
+                            <View>
+                                <Text 
+                                    variant="caption" 
+                                    style={{ color: d.Suggested ? '#16a085' : '#f39c12' }}
+                                >{d.Suggested ? 'HCW agreed' : 'HCW selected'}</Text>
+                            </View>
                         </View>
                     </Content>
                 );


### PR DESCRIPTION
Address feedback: https://neotree.atlassian.net/browse/NEOAPP-1205?focusedCommentId=26340

For the compiled diagnosis page, if possible, let’s not show the diagnoses which the HCWs disagreed with (remove them from the list), and the ones which the HCW selected themselves, i.e., from the above example - Hypoglycaemia and Birth asphyxia, can we say, HCW selected (maybe in yellow colour) next to them?

<img width="800" height="1280" alt="Screenshot_20260121-073038" src="https://github.com/user-attachments/assets/c8f8a365-cfd1-4c51-a2fd-44a68423f32b" />
