### PR TITLE
Sessions + Exports: fix duplicate interrupted records, make JSON API exports reliable with retry queue, gate local-server history + format/print local-server sessions like local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,8 @@ src/certs
 .env*
 !.env.example
 .eslintrc.js
+
+
+#zencoder
+.zencoder
+.zenflow

--- a/src/Home/Sessions/export/index.ts
+++ b/src/Home/Sessions/export/index.ts
@@ -1,15 +1,44 @@
 import XLSX from 'xlsx';
 import * as FileSystem from 'expo-file-system';
 import * as MediaLibrary from 'expo-media-library';
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as api from '../../../data';
 import moment from 'moment';
 import getJSON from './getJSON';
 import { APP_CONFIG } from '../../../constants';
 import * as types from '../../../types';
+import { ASYNC_STORAGE_KEYS } from '../../../constants/async-storage';
 
 export { getJSON };
 
 const getDate = () => moment(new Date()).format('YYYYMMDDhmm');
+
+const getExportQueue = async (): Promise<number[]> => {
+  try {
+    const raw = await AsyncStorage.getItem(ASYNC_STORAGE_KEYS.EXPORT_QUEUE);
+    const ids = raw ? JSON.parse(raw) : [];
+    return Array.isArray(ids) ? ids : [];
+  } catch {
+    return [];
+  }
+};
+
+const setExportQueue = async (ids: number[]) => {
+  const unique = Array.from(new Set((ids || []).filter((id) => Number.isFinite(id))));
+  await AsyncStorage.setItem(ASYNC_STORAGE_KEYS.EXPORT_QUEUE, JSON.stringify(unique));
+};
+
+const addToExportQueue = async (ids: number[]) => {
+  const existing = await getExportQueue();
+  await setExportQueue([...existing, ...(ids || [])]);
+};
+
+const removeFromExportQueue = async (ids: number[]) => {
+  const removeSet = new Set((ids || []).filter((id) => Number.isFinite(id)));
+  if (!removeSet.size) return;
+  const existing = await getExportQueue();
+  await setExportQueue(existing.filter((id) => !removeSet.has(id)));
+};
 
 const isSavingToDevicePermitted = () => new Promise((resolve, reject) => {
   (async () => {
@@ -143,7 +172,27 @@ export function exportToApi(opts: any = {}) {
   return new Promise((resolve, reject) => {
     (async () => {
       try {
-        const sessions = _sessions.filter((s: any) => !s.exported);
+        const queuedIds = await getExportQueue();
+        let queuedSessions: any[] = [];
+        if (queuedIds.length) {
+          const allSessions: any[] = (await api.getSessions()) as any[];
+          queuedSessions = (allSessions || []).filter(s => queuedIds.includes(s.id));
+          const existingIds = queuedSessions.map(s => s.id);
+          const missingIds = queuedIds.filter(id => !existingIds.includes(id));
+          if (missingIds.length) {
+            await removeFromExportQueue(missingIds);
+          }
+        }
+
+        const sessions = [
+          ..._sessions,
+          ...queuedSessions,
+        ]
+          .filter((s: any) => s && !s.exported)
+          .reduce((acc: any[], s: any) => {
+            if (!acc.some(e => e.id === s.id)) acc.push(s);
+            return acc;
+          }, []);
 
         try {
           if (opts.dontSaveFile !== true) await exportJSON(opts);
@@ -179,6 +228,7 @@ export function exportToApi(opts: any = {}) {
           // 1. Main session export to /sessions
           ...standardExportData.map((s: any, i: number) => ({
             type: 'main',
+            sessionId: sessions[i]?.id,
             execute: async () => {
               await api.exportSession(s);
               await api.updateSession({ exported: true }, { where: { id: sessions[i]?.id } });
@@ -189,6 +239,7 @@ export function exportToApi(opts: any = {}) {
           // 2. Local export to /local (if hasLocalConfig)
           ...(hasLocalConfig ? pollExportData.map((s: any, i: number) => ({
             type: 'local',
+            sessionId: sessions[i]?.id,
             execute: async () => {
               if (sessions[i]?.local_export) return { success: true, skipped: true };
 
@@ -212,11 +263,12 @@ export function exportToApi(opts: any = {}) {
           // 3. Poll data export to /save-poll-data
           ...pollExportData.map((s: any, i: number) => ({
             type: 'poll',
+            sessionId: sessions[i]?.id,
             execute: async () => {
               if (sessions[i]?.exported) return { success: true, skipped: true };
 
               const { id, exported, local_export, ...exportable } = s;
-              await api.makeApiCall(
+              const res = await api.makeApiCall(
                 'nodeapi',
                 `/save-poll-data?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`,
                 {
@@ -224,6 +276,9 @@ export function exportToApi(opts: any = {}) {
                   body: JSON.stringify(exportable),
                 }
               );
+              if (res?.status !== 200) {
+                throw new Error(`Failed to export poll data for session ${sessions[i]?.id}`);
+              }
               return { success: true, id: sessions[i]?.id };
             }
           }))
@@ -240,12 +295,30 @@ export function exportToApi(opts: any = {}) {
           .filter(({ result }) => result.status === 'rejected')
           .map(({ result, group }) => ({
             type: group.type,
+            sessionId: group.sessionId,
             error: result.status === 'rejected' ? result.reason : null
           }));
 
         if (failures.length > 0) {
           console.log('Export failures:', failures);
-          // Don't reject - allow partial success
+          const mainFailures = failures.filter(f => f.type === 'main');
+          if (mainFailures.length > 0) {
+            await addToExportQueue(mainFailures.map(f => f.sessionId).filter(Boolean));
+          }
+          if (mainFailures.length > 0) {
+            throw new Error(`Failed to export ${mainFailures.length} session(s). Check network and try again.`);
+          }
+          // Local/poll failures are treated as warnings
+        }
+
+        const mainSuccessIds = results
+          .map((result, index) => ({ result, group: apiCallGroups[index] }))
+          .filter(({ result, group }) => group.type === 'main' && result.status === 'fulfilled')
+          .map(({ group }) => group.sessionId)
+          .filter(Boolean);
+
+        if (mainSuccessIds.length > 0) {
+          await removeFromExportQueue(mainSuccessIds);
         }
 
         resolve(null);

--- a/src/Home/Sessions/index.tsx
+++ b/src/Home/Sessions/index.tsx
@@ -109,9 +109,11 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 			session?.scriptid;
 
 		let screens: any[] = [];
+		let scriptMeta: any = session?.data?.script;
 		try {
 			if (scriptId) {
 				const scriptRes: any = await api.getScript({ script_id: scriptId });
+				scriptMeta = scriptRes?.script || scriptMeta;
 				screens = scriptRes?.screens || [];
 			}
 		} catch {
@@ -310,8 +312,10 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 
 		return {
 			...session,
+			uid: session?.uid || session?.data?.uid,
 			data: {
 				...session.data,
+				script: scriptMeta || session?.data?.script,
 				form,
 			},
 		};

--- a/src/Home/Sessions/index.tsx
+++ b/src/Home/Sessions/index.tsx
@@ -76,6 +76,213 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 
     const [searchValue, setSearchValue] = React.useState('');
     const searchTimeout = React.useRef<any>();
+	const [localServerAvailable, setLocalServerAvailable] = React.useState(false);
+	const [localServerChecked, setLocalServerChecked] = React.useState(false);
+	const [searchingLocalServer, setSearchingLocalServer] = React.useState(false);
+	const [localServerError, setLocalServerError] = React.useState('');
+	const [searchSource, setSearchSource] = React.useState<null | 'local' | 'localServer'>(null);
+	const [loadingSessionDetails, setLoadingSessionDetails] = React.useState(false);
+
+	const normalizeSessionForDisplay = async (session: any) => {
+		if (!session) return session;
+		if (session?.data?.form && Array.isArray(session.data.form)) return session;
+		const entries = session?.data?.entries || {};
+		const repeatables = entries.repeatables || {};
+		const entriesByKey = Object.keys(entries).reduce((acc: any, key: string) => {
+			acc[key.toLowerCase()] = { entry: entries[key], originalKey: key };
+			return acc;
+		}, {});
+		const buildValueObjects = (labels: any, values: any) => {
+			const labelArr = Array.isArray(labels) ? labels : [labels];
+			const valueArr = Array.isArray(values) ? values : [values];
+			const maxLen = Math.max(labelArr.length, valueArr.length, 1);
+			return Array.from({ length: maxLen }).map((_, i) => ({
+				valueText: labelArr[i] ?? valueArr[i] ?? 'N/A',
+				value: valueArr[i] ?? labelArr[i] ?? 'N/A',
+			}));
+		};
+
+		const scriptId =
+			session?.data?.script?.id ||
+			session?.data?.script?.script_id ||
+			session?.data?.scriptTitle ||
+			session?.scriptid;
+
+		let screens: any[] = [];
+		try {
+			if (scriptId) {
+				const scriptRes: any = await api.getScript({ script_id: scriptId });
+				screens = scriptRes?.screens || [];
+			}
+		} catch {
+			screens = [];
+		}
+
+		const usedKeys = new Set<string>();
+		const form: any[] = [];
+
+		const pushScreenEntry = (screen: any, values: any[], repeatableGroup?: any) => {
+			if (!values.length && !repeatableGroup) return;
+			form.push({
+				screen: {
+					id: screen?.id || screen?.screen_id || screen?.data?.id || 'historic',
+					screen_id: screen?.screen_id || screen?.id || 'historic',
+					type: screen?.type || screen?.data?.type || 'form',
+					metadata: screen?.data?.metadata || { label: screen?.data?.title || 'Historic Data' },
+					title: screen?.data?.title || screen?.data?.metadata?.label || 'Historic Data',
+					sectionTitle: screen?.data?.sectionTitle || screen?.data?.metadata?.label || 'Historic Data',
+					listStyle: screen?.data?.listStyle,
+					printDisplayColumns: screen?.data?.printDisplayColumns,
+				},
+				values,
+				...(repeatableGroup ? { repeatables: repeatableGroup } : {}),
+			});
+		};
+
+		const buildValueFromEntry = (key: string, entry: any, fieldDef?: any) => {
+			if (!entry) return null;
+			const entryValues = entry.values || {};
+			const valueObjects = buildValueObjects(entryValues.label, entryValues.value);
+			const isMulti = valueObjects.length > 1;
+			const label = fieldDef?.label || entry.label || key;
+			const valuePayload = isMulti
+				? valueObjects.map((v) => ({
+						value: v.value,
+						valueText: v.valueText,
+						parentKey: key,
+					}))
+				: valueObjects[0]?.value ?? 'N/A';
+			const valueTextPayload = isMulti ? valuePayload : valueObjects[0]?.valueText ?? 'N/A';
+			return {
+				key,
+				type: fieldDef?.type || entry.type || 'text',
+				label,
+				value: valuePayload,
+				valueText: valueTextPayload,
+				dataType: fieldDef?.dataType,
+				unit: fieldDef?.unit,
+				parentKey: entry.parentKey || fieldDef?.parentKey || '',
+				printable: entry.printable !== false && fieldDef?.printable !== false,
+				prePopulate: entry.prePopulate || fieldDef?.prePopulate || [],
+				confidential: fieldDef?.confidential,
+				comments: entry.comments || [],
+			};
+		};
+
+		const diagnosesList = Array.isArray(session?.data?.diagnoses) ? session.data.diagnoses : [];
+		const diagnosesMap = diagnosesList.reduce((acc: any, item: any) => {
+			const key = Object.keys(item || {})[0];
+			if (!key) return acc;
+			acc[key] = item[key];
+			return acc;
+		}, {});
+		const diagnosisKeys = Object.keys(diagnosesMap).sort((a, b) => {
+			const pa = diagnosesMap[a]?.Priority ?? Number.MAX_SAFE_INTEGER;
+			const pb = diagnosesMap[b]?.Priority ?? Number.MAX_SAFE_INTEGER;
+			return pa - pb;
+		});
+
+		if (screens.length) {
+			screens.forEach((screen) => {
+				const metadata = screen?.data?.metadata || {};
+				const fields = (metadata.fields || []).map((f: any) => ({ ...f, _source: 'field' }));
+				const items = (metadata.items || []).map((f: any) => ({ ...f, _source: 'item' }));
+				const defs = [...fields, ...items];
+
+				const screenKeys = defs
+					.map((f: any) => f.key || f.value)
+					.filter((k: any) => k);
+
+				const values: any[] = [];
+				if (screen?.type === 'diagnosis') {
+					diagnosisKeys.forEach((key) => {
+						const d = diagnosesMap[key];
+						values.push({
+							key,
+							type: 'diagnosis',
+							label: d?.diagnosis || key,
+							value: d?.diagnosis || key,
+							valueText: d?.diagnosis || key,
+							diagnosis: {
+								name: d?.diagnosis || key,
+								how_agree: d?.hcw_agree,
+								hcw_follow_instructions: d?.hcw_follow_instructions,
+								suggested: d?.Suggested,
+								priority: d?.Priority,
+								hcw_reason_given: d?.hcw_reason_given,
+							},
+							printable: true,
+						});
+						usedKeys.add(key);
+					});
+				} else {
+					screenKeys.forEach((key: string) => {
+						const entryKey = `${key}`.toLowerCase();
+						const entryMatch = entriesByKey[entryKey];
+						if (!entryMatch) return;
+						const fieldDef = defs.find((d: any) => {
+							const defKey = `${d.key || d.value || ''}`.toLowerCase();
+							return defKey === entryKey;
+						});
+						const val = buildValueFromEntry(entryMatch.originalKey, entryMatch.entry, fieldDef);
+						if (val) {
+							values.push(val);
+							usedKeys.add(entryMatch.originalKey);
+						}
+					});
+				}
+
+				const repeatableGroup =
+					metadata?.repeatable && metadata?.collectionName
+						? repeatables?.[metadata.collectionName]
+						: null;
+
+				pushScreenEntry(screen, values, repeatableGroup);
+			});
+		}
+
+		const remainingKeys = Object.keys(entries).filter((key) => key !== 'repeatables' && !usedKeys.has(key));
+		if (remainingKeys.length) {
+			const values = remainingKeys
+				.map((key) => buildValueFromEntry(key, entries[key]))
+				.filter(Boolean);
+			pushScreenEntry(
+				{
+					id: 'historic',
+					screen_id: 'historic',
+					type: 'form',
+					data: { metadata: { label: 'Historic Data' }, title: 'Historic Data', sectionTitle: 'Historic Data' },
+				},
+				values
+			);
+		}
+
+		if (Object.keys(repeatables).length) {
+			const alreadyHandled = screens.some((s) => s?.data?.metadata?.repeatable);
+			if (!alreadyHandled) {
+				form.push({
+					screen: {
+						id: 'historic-repeatables',
+						screen_id: 'historic-repeatables',
+						type: 'form',
+						metadata: { label: 'Historic Data' },
+						title: 'Historic Data',
+						sectionTitle: 'Historic Data',
+					},
+					values: [],
+					repeatables,
+				});
+			}
+		}
+
+		return {
+			...session,
+			data: {
+				...session.data,
+				form,
+			},
+		};
+	};
 
 	const exportSessions = async (opts: any = {}) => {
 		const _dbSessions = dbSessions.filter((s: any) => s?.data?.completed_at);
@@ -280,6 +487,10 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 
 					const application = await api.getApplication();
 					setApplication(application);
+
+					const hasLocalServer = await api.hasLocalServerConfig();
+					setLocalServerAvailable(hasLocalServer);
+					setLocalServerChecked(true);
 				} catch (e) { console.log(e); /* DO NOTHING */ }
 			})();
 		}
@@ -348,6 +559,50 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 		);
 	}
 
+	const runSearch = async (value: string) => {
+		const trimmed = (value || '').trim();
+		setLocalServerError('');
+		if (!trimmed) {
+			setSearchSource(null);
+			setSessions(getFilteredSessions(dbSessions, { searchValue: trimmed }));
+			return;
+		}
+
+		const localMatches = getFilteredSessions(dbSessions, { searchValue: trimmed });
+		if (localMatches.length) {
+			setSearchSource('local');
+			setSessions(localMatches);
+			return;
+		}
+
+		if (!localServerAvailable) {
+			setSearchSource(null);
+			setSessions([]);
+			setLocalServerError('Local server not configured for this site.');
+			return;
+		}
+
+		try {
+			setSearchingLocalServer(true);
+			const location = await api.getLocation();
+			const hospital = location?.hospital;
+			if (!hospital) throw new Error('Hospital not set');
+			const remoteSessions: any = await api.getLocalSessionsByUID(trimmed, hospital, { partial: true });
+			const remoteError = remoteSessions?.[0]?.error;
+			if (remoteError) throw new Error(remoteError);
+			const normalized = (remoteSessions || []).map((s: any) => ({ ...s, __source: 'localServer' }));
+			setSearchSource('localServer');
+			setSessions(normalized);
+			if (!normalized.length) setLocalServerError('No results found on local server.');
+		} catch (e: any) {
+			setSearchSource(null);
+			setSessions([]);
+			setLocalServerError(e?.message || 'Local server unavailable.');
+		} finally {
+			setSearchingLocalServer(false);
+		}
+	};
+
 	return (
 		<>
             <Content>
@@ -357,16 +612,31 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
                     onChangeText={searchValue => {
                         setSearchValue(searchValue);
                         if (searchTimeout.current) clearTimeout(searchTimeout.current);
-                        searchTimeout.current = setTimeout(() => setSessions(getFilteredSessions(dbSessions, { searchValue })), 1000);
+                        searchTimeout.current = setTimeout(() => runSearch(searchValue), 1000);
                     }}
                 />
+				{!!searchingLocalServer && (
+					<Box marginTop="s">
+						<Text variant="caption" color="textSecondary">Searching local server…</Text>
+					</Box>
+				)}
+				{!!localServerError && (
+					<Box marginTop="s">
+						<Text variant="caption" color="textSecondary">{localServerError}</Text>
+					</Box>
+				)}
+				{searchSource === 'localServer' && (
+					<Box marginTop="s">
+						<Text variant="caption" color="textSecondary">Showing results from local server</Text>
+					</Box>
+				)}
             </Content>
 
 			<FlatList
 				data={sessions}
 				onRefresh={getSessions}
 				refreshing={loadingSessions}
-				keyExtractor={(item: any) => `${item.id}`}
+				keyExtractor={(item: any, index) => `${item.id || item?.data?.unique_key || item?.unique_key || index}`}
 				ListHeaderComponent={() => (
 					<Content>
 						{filterByDate && (
@@ -380,7 +650,11 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 				ListEmptyComponent={() => (
 					<Content>
 						<Box style={{ paddingVertical: 25 }}>
-							<Text style={{ textAlign: 'center', color: '#999' }}>No sessions to display</Text>
+							<Text style={{ textAlign: 'center', color: '#999' }}>
+								{searchValue && localServerChecked && !localServerAvailable
+									? 'Historic search unavailable: no local server configured.'
+									: 'No sessions to display'}
+							</Text>
 						</Box>
 					</Content>
 				)}
@@ -390,8 +664,14 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 						<>
 							<Content>
 								<TouchableOpacity
-									onPress={() => setSelectedSession(item)}
+									onPress={async () => {
+										setLoadingSessionDetails(true);
+										const formatted = await normalizeSessionForDisplay(item);
+										setSelectedSession(formatted);
+										setLoadingSessionDetails(false);
+									}}
 									onLongPress={() => {
+										if (!item?.id) return;
 										Alert.alert(
 											'Delete session',
 											'Do you want to delete this session?',
@@ -652,7 +932,7 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 				)}
 			</Modal>
 
-			{(deletingSessions || exportingSessions) && <OverlayLoader />}
+			{(deletingSessions || exportingSessions || loadingSessionDetails) && <OverlayLoader />}
 		</>
 	);
 }

--- a/src/Home/Sessions/index.tsx
+++ b/src/Home/Sessions/index.tsx
@@ -254,6 +254,26 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 							usedKeys.add(entryMatch.originalKey);
 						}
 					});
+
+					// Non-form screens often use metadata.key instead of fields/items
+					if (!screenKeys.length && metadata?.key) {
+						const metaKey = `${metadata.key}`.toLowerCase();
+						const entryMatch = entriesByKey[metaKey];
+						if (entryMatch) {
+							const val = buildValueFromEntry(entryMatch.originalKey, entryMatch.entry, {
+								key: metadata.key,
+								label: metadata.label,
+								type: metadata.type || screen?.type,
+								dataType: metadata.dataType,
+								printable: screen?.data?.printable,
+								confidential: metadata.confidential,
+							});
+							if (val) {
+								values.push(val);
+								usedKeys.add(entryMatch.originalKey);
+							}
+						}
+					}
 				}
 
 				const repeatableGroup =
@@ -266,19 +286,8 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 		}
 
 		const remainingKeys = Object.keys(entries).filter((key) => key !== 'repeatables' && !usedKeys.has(key));
-		if (remainingKeys.length) {
-			const values = remainingKeys
-				.map((key) => buildValueFromEntry(key, entries[key]))
-				.filter(Boolean);
-			pushScreenEntry(
-				{
-					id: 'historic',
-					screen_id: 'historic',
-					type: 'form',
-					data: { metadata: { label: 'Historic Data' }, title: 'Historic Data', sectionTitle: 'Historic Data' },
-				},
-				values
-			);
+		if (remainingKeys.length && __DEV__) {
+			console.log('[Sessions][normalizeSessionForDisplay] Unmapped keys:', remainingKeys);
 		}
 
 		if (Object.keys(repeatables).length) {

--- a/src/Home/Sessions/index.tsx
+++ b/src/Home/Sessions/index.tsx
@@ -118,6 +118,30 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 			screens = [];
 		}
 
+		if (scriptId) {
+			try {
+				const keys = Object.keys(entries).filter((key) => key !== 'repeatables');
+				const aliasPairs = await Promise.all(
+					keys.map(async (key) => {
+						const aliasRes: any = await api.getAliasKeyFromAliasAndScript({
+							script: scriptId,
+							alias: key,
+						});
+						return { key, alias: aliasRes?.name };
+					})
+				);
+				aliasPairs.forEach(({ key, alias }) => {
+					if (!alias) return;
+					const aliasKey = `${alias}`.toLowerCase();
+					if (!entriesByKey[aliasKey]) {
+						entriesByKey[aliasKey] = entriesByKey[`${key}`.toLowerCase()];
+					}
+				});
+			} catch {
+				// ignore alias lookup failures
+			}
+		}
+
 		const usedKeys = new Set<string>();
 		const form: any[] = [];
 

--- a/src/constants/async-storage.ts
+++ b/src/constants/async-storage.ts
@@ -1,3 +1,4 @@
 export const ASYNC_STORAGE_KEYS = {
     SYNC_ERROR: 'SYNC_ERROR',
+    EXPORT_QUEUE: 'EXPORT_QUEUE',
 };

--- a/src/contexts/script/index.tsx
+++ b/src/contexts/script/index.tsx
@@ -753,7 +753,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
                 reject(e);
             }
         })();
-    }), [createSessionSummary]);
+    }), [createSessionSummary, sessionID]);
 
     const createSummaryAndSaveSession = useCallback((params?: any) => new Promise((resolve, reject) => {
         setDisplayLoader(true);

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -203,6 +203,20 @@ export async function makeLocalGetApiCall(
         throw e; }
 }
 
+export async function hasLocalServerConfig() {
+    try {
+        const location = await getLocation();
+        const country = location?.country;
+        if (!country) return false;
+        const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)['local'];
+        const hospital = location?.hospital;
+        const localConfig = Array.isArray(config) ? config.filter(c => c.hospital === hospital?.trim()) : [];
+        return Boolean(localConfig?.[0]?.hospital?.length);
+    } catch {
+        return false;
+    }
+}
+
 export const getHospitals = async (params = {}, otherParams: Partial<(typeof _otherOptions)> = {}) => {
 	const res = await makeApiCall('webeditor', `/get-hospitals?${queryString.stringify(params)}`, undefined, otherParams);
 	const json = await res.json();

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -94,13 +94,22 @@ export const getExportedSessionsByUID = (uid: string) => new Promise<any[]>((res
     })();
 });
 
-export const getLocalSessionsByUID = (uid: string, hospital: string) => new Promise<any[]>((resolve, reject) => {
+export const getLocalSessionsByUID = (
+    uid: string,
+    hospital: string,
+    opts: { partial?: boolean } = {}
+) => new Promise<any[]>((resolve, reject) => {
     (async () => {
         if (!uid) return reject(new Error('UID is required'));
 
         try {
-
-            const res = await makeLocalGetApiCall(`/localByUid?uid=${uid}&hospital=${hospital}`);
+            const { partial } = opts;
+            const query = [
+                `uid=${encodeURIComponent(uid)}`,
+                `hospital=${encodeURIComponent(hospital)}`,
+                partial ? 'partial=true' : null,
+            ].filter(Boolean).join('&');
+            const res = await makeLocalGetApiCall(`/localByUid?${query}`);
             resolve(Object.values({
                 ...(res || [])
                     .reduce((acc: any, s: any) => ({


### PR DESCRIPTION
## This PR is for the following tickets
[NEOAPP-1157](https://neotree.atlassian.net/browse/NEOAPP-1157)
[NEOAPP-1228](https://neotree.atlassian.net/browse/NEOAPP-1228)
[NEOAPP-1226](https://neotree.atlassian.net/browse/NEOAPP-1226)

Summary
This PR fixes multiple issues across Sessions, exporting, and local-server history. It removes duplicate “Interrupted” records caused by stale session IDs, makes JSON API export success accurate (with a retry queue for failed exports), gates historic search to sites with local servers only, adds partial ID search for local server, and normalizes local-server payloads to match local session formatting/printing exactly.