### PR TITLE
Fixes inconsistent form field rendering on some screens.

### DIFF
--- a/src/Home/Script/Screen/_TypeForm/Repeatable.tsx
+++ b/src/Home/Script/Screen/_TypeForm/Repeatable.tsx
@@ -7,6 +7,7 @@ import { TextField } from './_Text';
 import { DropDownField } from './_DropDown';
 import { PeriodField, dateToValueText } from './_Period';
 import { TimeField } from './_Time';
+import { MultiSelectField } from './_MultiSelect';
 import { fieldsTypes } from '../../../../constants';
 import { formatDate } from '@/src/utils/formatDate';
 
@@ -42,6 +43,10 @@ const normalizeFormEntries = (values?: Record<string, any>) => {
         }
         return acc;
     }, []);
+};
+
+const normalizeFieldType = (fieldType: any) => {
+    return `${fieldType ?? ''}`.trim().toLowerCase().replace(/[\s-]+/g, '_');
 };
 
 
@@ -177,7 +182,7 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
 
         if (value) {
             const field = fields.find(field => field.key === collectionField)
-            if (field && field.type === 'dropdown') {
+            if (field && normalizeFieldType(field.type) === 'dropdown') {
                 if (value['value'] === 'other') {
                     const otherField = fields.find(f => String(f.key).toLocaleLowerCase() === String('other' + field.key).toLocaleLowerCase())
 
@@ -439,11 +444,13 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
                 ...valueObj,
             };
 
-            if (field.type === 'dropdown' && base) {
+            const normalizedFieldType = normalizeFieldType(field.type);
+
+            if (normalizedFieldType === 'dropdown' && base) {
                 const dropdownInfo = getValueLabelAndText(field, valueObj.value);
                 if (dropdownInfo !== null)
                     Object.assign(base, dropdownInfo);
-            } else if (field.type === 'period' && base) {
+            } else if (normalizedFieldType === 'period' && base) {
                 const calc = String(field?.calculation)?.replace("$", "");
                 const calValue = partial[calc]?.value;
                 
@@ -462,7 +469,7 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
                         // Don't assign period info if date is invalid
                     }
                 }
-            } else if (base && (field.type === 'date' || field.type === 'datetime')) {
+            } else if (base && (normalizedFieldType === 'date' || normalizedFieldType === 'datetime')) {
                 // Validate date before formatting
                 if (valueObj.value) {
                     try {
@@ -522,7 +529,7 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
         }
         const componentKey = `${formId}-${field.key}`;
 
-        switch (field.type) {
+        switch (normalizeFieldType(field.type)) {
             case fieldsTypes.NUMBER:
                 return <NumberField key={componentKey} {...fieldProps} />;
             case fieldsTypes.DATE:
@@ -536,6 +543,8 @@ const Repeatable = ({ collectionName, collectionField, fields, onChange, evaluat
                 return <TextField key={componentKey} {...fieldProps} />;
             case fieldsTypes.TIME:
                 return <TimeField key={componentKey} {...fieldProps} />;
+            case fieldsTypes.MULTI_SELECT:
+                return <MultiSelectField key={componentKey} {...fieldProps} />;
             default:
                 return null;
         }

--- a/src/Home/Script/Screen/_TypeForm/index.tsx
+++ b/src/Home/Script/Screen/_TypeForm/index.tsx
@@ -34,21 +34,25 @@ export function TypeForm({ }: TypeFormProps) {
     } = ctx;
 
 //Fix Slowness Issue, By Prebuilding Fields Before Rendering
+    const normalizeFieldType = React.useCallback((fieldType: any) => {
+        return `${fieldType ?? ''}`.trim().toLowerCase().replace(/[\s-]+/g, '_');
+    }, []);
   
-   const metadata = React.useMemo(() => {
+    const metadata = React.useMemo(() => {
     const original = activeScreen?.data?.metadata;
     if (!original?.fields) return original;
 
     const hasManual = original.fields.some(
         (f: any) =>
-            f.type === "dropdown" &&
+            normalizeFieldType(f.type) === "dropdown" &&
             Array.isArray(f.items) &&
             f.items.some((i: any) => i.enterValueManually === true)
     );
 
     // Transform dropdown and multi_select fields to clear values if items is not empty
     const transformedFields = original.fields.map((field: any) => {
-        if ((field.type === "dropdown" || field.type === "multi_select") && Array.isArray(field.items) && field.items.length > 0) {
+        const normalizedType = normalizeFieldType(field.type);
+        if ((normalizedType === "dropdown" || normalizedType === "multi_select") && Array.isArray(field.items) && field.items.length > 0) {
             return {
                 ...field,
                 values: "",
@@ -72,7 +76,7 @@ export function TypeForm({ }: TypeFormProps) {
             position: positionCounter++,
         });
 
-        if (field.type === "dropdown" && Array.isArray(field.items)) {
+        if (normalizeFieldType(field.type) === "dropdown" && Array.isArray(field.items)) {
             const manualItems = field.items.filter(
                 (i: any) => i.enterValueManually === true
             );
@@ -106,7 +110,7 @@ export function TypeForm({ }: TypeFormProps) {
         ...original,
         fields: updatedFields,
     };
-}, [activeScreen?.data?.metadata]);
+}, [activeScreen?.data?.metadata, normalizeFieldType]);
 
     const cachedVal = activeScreenEntry?.values || [];
     const canAutoFill = !mountedScreens[activeScreen?.id];
@@ -140,7 +144,9 @@ export function TypeForm({ }: TypeFormProps) {
                 valueText = cached?.valueText || patientNUID;
             }
 
-            if (f.type === 'multi_select') {
+            const normalizedFieldType = normalizeFieldType(f.type);
+
+            if (normalizedFieldType === 'multi_select') {
                 const opts = (() => {
                     if (!f?.items) {
                         return parseFieldValues({
@@ -168,7 +174,7 @@ export function TypeForm({ }: TypeFormProps) {
                 }));
             }
 
-            if (f.type === 'dropdown') {
+            if (normalizedFieldType === 'dropdown') {
                 const opts = (() => {
                     if (!f?.items) {
                         return parseFieldValues({
@@ -213,7 +219,7 @@ export function TypeForm({ }: TypeFormProps) {
                 printDisplayColumns: f.printDisplayColumns || activeScreen?.data?.printDisplayColumns,
             };
         });
-    }, [repeatable, metadata, canAutoFill, cachedVal,  activeScreen?.printDisplayColumns, getPrepopulationData]);
+    }, [repeatable, metadata, canAutoFill, cachedVal,  activeScreen?.printDisplayColumns, getPrepopulationData, normalizeFieldType]);
 
     const [values, setValues] = React.useState<types.ScreenEntryValue[]>(getValues());
 
@@ -229,10 +235,11 @@ export function TypeForm({ }: TypeFormProps) {
             }
 
         }
-        if (f.condition!="") {
-            
+        const condition = `${f?.condition ?? ''}`.trim();
+
+        if (condition) {
             conditionMet = evaluateCondition(
-                parseCondition(f.condition, [{ values: formatedvalues }])
+                parseCondition(condition, [{ values: formatedvalues }])
             ) as boolean;
         }
        
@@ -450,7 +457,8 @@ export function TypeForm({ }: TypeFormProps) {
                     <React.Fragment key={f.key}>
                         {(() => {
                             let Component: null | React.ComponentType<types.ScreenFormTypeProps & { patientNUID?: string | null; }> = null;
-                            switch (f.type) {
+                            const normalizedFieldType = normalizeFieldType(f.type);
+                            switch (normalizedFieldType) {
                                 case fieldsTypes.NUMBER:
                                     Component = NumberField;
                                     break;
@@ -487,7 +495,7 @@ export function TypeForm({ }: TypeFormProps) {
                             if (!conditionMet) return null;
 
                             const updateFieldValue = (val: Partial<types.ScreenEntryValue>) => setValue(i, val);
-                            const shouldLog = ['date', 'datetime', 'period'].includes(f.type);
+                            const shouldLog = ['date', 'datetime', 'period'].includes(normalizedFieldType);
                             const onChange = (val: Partial<types.ScreenEntryValue>) => {
                                 if (shouldLog) {
                                     const incoming = val || {};


### PR DESCRIPTION
### Root cause

Fields with condition as null/undefined were still being condition-evaluated due to f.condition != "", causing false evaluations and hidden fields.

Some field type values were not normalized, so payload variants could fail component matching and skip rendering.

Repeatable forms were missing multi_select render support.

### Changes

Updated TypeForm condition logic to evaluate only when condition is non-empty after trim.

Added field type normalization (trim + lowercase + hyphen/space -> underscore) and used normalized type for field handling/rendering.

Applied the same normalization in Repeatable.

Added multi_select support in repeatable field rendering.