### PR TITLE
Fix export to excel

### DIFF
--- a/src/Home/Sessions/export/index.ts
+++ b/src/Home/Sessions/export/index.ts
@@ -40,6 +40,43 @@ const removeFromExportQueue = async (ids: number[]) => {
   await setExportQueue(existing.filter((id) => !removeSet.has(id)));
 };
 
+const getExcelEntryValue = ({
+  entry,
+  entryKey,
+  scriptId,
+  sessionId,
+}: {
+  entry: any;
+  entryKey: string;
+  scriptId: string;
+  sessionId?: number;
+}) => {
+  if (entryKey === 'repeatables') {
+    return null;
+  }
+
+  const rawValue = entry?.values?.value;
+
+  if (Array.isArray(rawValue)) {
+    return rawValue
+      .filter((value) => value !== null && value !== undefined && value !== '')
+      .join(', ');
+  }
+
+  if (rawValue !== undefined && rawValue !== null) {
+    return String(rawValue);
+  }
+
+  console.error('Excel export entry missing values.value', {
+    scriptId,
+    sessionId,
+    entryKey,
+    entry,
+  });
+
+  return 'N/A';
+};
+
 const isSavingToDevicePermitted = () => new Promise((resolve, reject) => {
   (async () => {
     try {
@@ -100,9 +137,23 @@ export function exportEXCEL(opts: any = {}) {
     (async () => {
       try {
         const permissionGranted = await isSavingToDevicePermitted();
-        if (!permissionGranted) return reject(new Error('App has not been granted permission to save files to device'));
+        if (!permissionGranted) {
+          const error = new Error('App has not been granted permission to save files to device');
+          console.error('Excel export permission denied', {
+            sessionCount: sessions.length,
+            format: opts.format,
+          });
+          return reject(error);
+        }
 
         const { granted, directoryUri }: any = await FileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync();
+
+        if (!granted) {
+          console.error('Excel export directory permission not granted', {
+            sessionCount: sessions.length,
+            format: opts.format,
+          });
+        }
 
         if (granted) {
           const scripts = sessions.reduce((acc: any, { data: { script } }: any) => ({
@@ -128,9 +179,20 @@ export function exportEXCEL(opts: any = {}) {
                 const data = json[scriptId].map((e: any) => {
                   const values = Object.keys(e.entries).reduce((acc: any, entryKey) => {
                     const entry = e.entries[entryKey];
+                    const entryValue = getExcelEntryValue({
+                      entry,
+                      entryKey,
+                      scriptId,
+                      sessionId: e.id,
+                    });
+
+                    if (entryValue === null) {
+                      return acc;
+                    }
+
                     return {
                       ...acc,
-                      [entryKey || 'N/A']: entry.values.value.join(', ')
+                      [entryKey || 'N/A']: entryValue
                     };
                   }, null);
                   return !values ? null : keys.reduce((acc: any, key: any) => ({ ...acc, [key]: values[key] || 'N/A' }), {});
@@ -144,7 +206,15 @@ export function exportEXCEL(opts: any = {}) {
                 const wbout = XLSX.write(wb, { type: 'base64', bookType: 'xlsx' });
         
                 resolve([fileUri, wbout]);
-              } catch (e) { reject(e); }
+              } catch (e) {
+                console.error('Excel export sheet generation failed', {
+                  scriptId,
+                  scriptTitle: scripts[scriptId]?.data?.title,
+                  sessionCount: json[scriptId]?.length || 0,
+                  error: e,
+                });
+                reject(e);
+              }
             })();
           })));
     
@@ -154,14 +224,27 @@ export function exportEXCEL(opts: any = {}) {
                 try {
                   await FileSystem.writeAsStringAsync(fileUri, wbout, { encoding: FileSystem.EncodingType.Base64 });
                   resolve(null);
-                } catch (e) { reject(e); }
+                } catch (e) {
+                  console.error('Excel export file write failed', {
+                    fileUri,
+                    error: e,
+                  });
+                  reject(e);
+                }
               })();
             })));
           }
         }
 
         resolve(null);
-      } catch (e) { reject(e); }
+      } catch (e) {
+        console.error('Excel export failed', {
+          sessionCount: sessions.length,
+          format: opts.format,
+          error: e,
+        });
+        reject(e);
+      }
     })();
   });
 }

--- a/src/Home/Sessions/index.tsx
+++ b/src/Home/Sessions/index.tsx
@@ -346,6 +346,13 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 				]
 			);
 		} catch (e: any) {
+			if (exportFormat === 'excel') {
+				console.error('Excel export failed from Sessions screen', {
+					exportType,
+					sessionCount: Array.isArray(sessions) ? sessions.length : 0,
+					error: e,
+				});
+			}
 			Alert.alert(
 				'Failed to export data',
 				e.message || e.msg || JSON.stringify(e),


### PR DESCRIPTION
## Summary

This PR is for ticket [NEOAPP1286](https://neotree.atlassian.net/browse/NEOAPP-1286)

This PR improves Excel export diagnostics and hardens the export flow against malformed session entry data.

Previously, Excel export could fail with a runtime error when the exporter assumed every `entries` item had a `values.value` array. In practice, some exported objects such as `repeatables` do not match that shape, which caused workbook generation to crash without enough context to debug quickly.
