### PR TITLE
Block printing for incomplete or interrupted admission sessions

### DIFF
--- a/src/components/Session/Print.tsx
+++ b/src/components/Session/Print.tsx
@@ -6,6 +6,8 @@ import formToHTML from './formToHTML';
 import { printSectionsToHTML } from "./printSectionsToHTML";
 import { useTheme } from "../Theme";
 import { OverlayLoader } from "../OverlayLoader";
+import { getSessionPrintBlockMessage, isSessionPrintable } from "./printEligibility";
+import { PrintBlockedDialog } from "./PrintBlockedDialog";
 
 type PrintSessionProps = {
     session: any;
@@ -17,8 +19,15 @@ export function PrintSession({ session, showConfidential }: PrintSessionProps) {
 
     const [printing, setPrinting] = React.useState(false);
     const [, setPrintingError] = React.useState(false);
+    const [showBlockedDialog, setShowBlockedDialog] = React.useState(false);
+    const printable = isSessionPrintable(session);
 
     const print = async () => {
+        if (!printable) {
+            setShowBlockedDialog(true);
+            return;
+        }
+
         try {
             setPrinting(true);
             let html = await formToHTML(session, showConfidential);
@@ -37,13 +46,22 @@ export function PrintSession({ session, showConfidential }: PrintSessionProps) {
     return (
         <>
             {printing && <OverlayLoader transparent backgroundColor="rgba(255,255,255,.5)" />}
+            <PrintBlockedDialog
+                open={showBlockedDialog}
+                message={getSessionPrintBlockMessage(session)}
+                onClose={() => setShowBlockedDialog(false)}
+            />
 
             <TouchableOpacity
                 style={{ paddingHorizontal: 10 }}
                 onPress={() => print()}
                 disabled={printing}
             >
-                <Icon color={theme.colors.secondary} size={24} name="print" />
+                <Icon
+                    color={printable ? theme.colors.secondary : theme.colors.textDisabled}
+                    size={24}
+                    name="print"
+                />
             </TouchableOpacity>
         </>
     )

--- a/src/components/Session/PrintBarCode.tsx
+++ b/src/components/Session/PrintBarCode.tsx
@@ -14,6 +14,8 @@ import {
 } from "tp-react-native-bluetooth-printer";
 import { Button } from "../Button";
 import { ASYNC_STORAGE_KEYS } from "../../constants/async-storage";
+import { getSessionPrintBlockMessage, isSessionPrintable } from "./printEligibility";
+import { PrintBlockedDialog } from "./PrintBlockedDialog";
 
 type PrintBarCodeProps = {
     session: any;
@@ -22,6 +24,8 @@ type PrintBarCodeProps = {
 };
 export function PrintBarCode({ session, isGeneric, onPrinted }: PrintBarCodeProps) {
     const theme = useTheme();
+    const printable = isGeneric || isSessionPrintable(session);
+    const [showBlockedDialog, setShowBlockedDialog] = React.useState(false);
 
     const [printer, setPrinter] = React.useState<any>(null);
     const [printing, setPrinting] = React.useState(false)
@@ -557,6 +561,11 @@ export function PrintBarCode({ session, isGeneric, onPrinted }: PrintBarCodeProp
     };
 
     const print = async () => {
+        if (!printable) {
+            setShowBlockedDialog(true);
+            return;
+        }
+
         setPrinting(true)
         const uid = session?.uid || session?.['uid'];
         if (!uid) {
@@ -592,6 +601,11 @@ export function PrintBarCode({ session, isGeneric, onPrinted }: PrintBarCodeProp
     }
     return (
         <Box style={{ maxHeight: 45, overflow: 'hidden' }}>
+            <PrintBlockedDialog
+                open={showBlockedDialog}
+                message={getSessionPrintBlockMessage(session)}
+                onClose={() => setShowBlockedDialog(false)}
+            />
             {isGeneric ?
                 <Button
                     hitSlop={{ bottom: 20, left: 20, right: 20 }}
@@ -610,9 +624,9 @@ export function PrintBarCode({ session, isGeneric, onPrinted }: PrintBarCodeProp
                     hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
                     style={{ alignItems: 'flex-start' }}
                 >
-                    {!printing && !connecting ? (printerConnected ? <Icon color={theme.colors.primary} size={40} name="qr-code" />
-                        : (bluetoothEnabled ? <Icon color={"blue"} size={40} name="qr-code" />
-                            : <Icon color={theme.colors.error} size={40} name="qr-code" />))
+                    {!printing && !connecting ? (printerConnected ? <Icon color={printable ? theme.colors.primary : theme.colors.textDisabled} size={40} name="qr-code" />
+                        : (bluetoothEnabled ? <Icon color={printable ? "blue" : theme.colors.textDisabled} size={40} name="qr-code" />
+                            : <Icon color={printable ? theme.colors.error : theme.colors.textDisabled} size={40} name="qr-code" />))
                         : (
                             <ActivityIndicator
                                 color={theme.colors.primary}

--- a/src/components/Session/PrintBlockedDialog.tsx
+++ b/src/components/Session/PrintBlockedDialog.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import Icon from '@expo/vector-icons/MaterialIcons';
+import { Box, Text, useTheme } from "../Theme";
+import { Button } from "../Button";
+import { Modal } from "../Modal";
+
+type PrintBlockedDialogProps = {
+    open: boolean;
+    message: string;
+    onClose: () => void;
+};
+
+export function PrintBlockedDialog({ open, message, onClose }: PrintBlockedDialogProps) {
+    const theme = useTheme();
+
+    return (
+        <Modal open={open} onClose={onClose}>
+            <Box alignItems="center">
+                <Box
+                    width={64}
+                    height={64}
+                    borderRadius="xl"
+                    alignItems="center"
+                    justifyContent="center"
+                    marginBottom="m"
+                    style={{ backgroundColor: `${theme.colors.error}18` }}
+                >
+                    <Icon name="report-problem" size={30} color={theme.colors.error} />
+                </Box>
+
+                <Text variant="title2" color="primary" textAlign="center">
+                    Unable to print
+                </Text>
+
+                <Box marginTop="m" marginBottom="l">
+                    <Text color="textSecondary" textAlign="center">
+                        {message}
+                    </Text>
+                </Box>
+
+                <Box
+                    width="100%"
+                    padding="m"
+                    borderRadius="s"
+                    marginBottom="l"
+                    style={{ backgroundColor: `${theme.colors.warning}14` }}
+                >
+                    <Text color="textSecondary" textAlign="center">
+                        Admission paper notes and QR labels are only available after the session is completed.
+                    </Text>
+                </Box>
+
+                <Button color="primary" onPress={onClose}>
+                    OK
+                </Button>
+            </Box>
+        </Modal>
+    );
+}

--- a/src/components/Session/printEligibility.ts
+++ b/src/components/Session/printEligibility.ts
@@ -1,0 +1,10 @@
+export function isSessionPrintable(session: any) {
+    return !!(session?.data?.completed_at || session?.data?.canceled_at);
+}
+
+export function getSessionPrintBlockMessage(session: any) {
+    if (isSessionPrintable(session)) return '';
+
+    const scriptTitle = session?.data?.script?.data?.title || 'This session';
+    return `${scriptTitle} cannot be printed because it is incomplete or was interrupted. Complete the session before printing notes or QR labels.`;
+}


### PR DESCRIPTION
**Description**
This PR prevents clinicians from printing admission paper notes or session QR labels when a session has not been completed.

The change addresses the case from ticket `#1250`, where incomplete admission notes were printed and attached to the patient file, then the same UID was reused at discharge. Because the admission record had never been completed, no matching record was found on the server.
