### PR TITLE
twin search hardening

### DIFF
--- a/src/Home/Script/Screen/_TypeForm/index.tsx
+++ b/src/Home/Script/Screen/_TypeForm/index.tsx
@@ -130,7 +130,7 @@ export function TypeForm({ }: TypeFormProps) {
             ));
         const nuidSearch = nuidSearchForm.find(f => (
             f.results &&
-            f.results.prePopulateWithUID !== false &&
+            f.results.useSearchedUidForSession === true &&
             (f.value || f.results.uid || f.results.searchedUid)
         ));
 

--- a/src/Home/Script/Start/Search.tsx
+++ b/src/Home/Script/Start/Search.tsx
@@ -14,6 +14,9 @@ type SearchProps = {
     autofillKeys?: string[];
     filterEntries?: (entry: any) => any;
     prePopulateWithUID?: boolean;
+    useSearchedUidForSession?: boolean;
+    noRecordTitle?: string;
+    noRecordMessage?: (uid: string) => string;
 };
 
 const getSessionKey = (session: any, index?: number) => {
@@ -47,10 +50,15 @@ const hasFullQrSession = (session: any) => {
 
 const normalizeQrSession = (session: any) => {
     if (!hasFullQrSession(session)) return session;
-    if (session?.data) return session;
+    if (session?.data) {
+        return {
+            ...session,
+            uid: session.uid || session.data?.uid,
+        };
+    }
 
     return {
-        uid: session.uid,
+        uid: session.uid || session.data?.uid,
         data: {
             ...session,
             uid: session.uid,
@@ -76,7 +84,16 @@ const mergeSearchResults = (...groups: any[][]) => {
 };
 
 
-export function Search({ onSession, label, autofillKeys, filterEntries, prePopulateWithUID, }: SearchProps) {
+export function Search({
+    onSession,
+    label,
+    autofillKeys,
+    filterEntries,
+    prePopulateWithUID,
+    useSearchedUidForSession = prePopulateWithUID !== false,
+    noRecordTitle = 'No matching record found',
+    noRecordMessage,
+}: SearchProps) {
     const { setMatched } = useScriptContext();
 
     const [uid, setUID] = React.useState('');
@@ -175,24 +192,26 @@ export function Search({ onSession, label, autofillKeys, filterEntries, prePopul
             uid,
             facility: facility as types.Facility,
             autoFill,
-            prePopulateWithUID: prePopulateWithUID
+            prePopulateWithUID,
+            useSearchedUidForSession,
         } : null;
-    }, [autofillKeys, facility, filterEntries, prePopulateWithUID, uid]);
+    }, [autofillKeys, facility, filterEntries, prePopulateWithUID, uid, useSearchedUidForSession]);
 
     const resolveUIDWithoutMatch = React.useCallback(() => {
         const initialSession = {
             session: null,
-            uid: prePopulateWithUID === false ? '' : uid,
+            uid: useSearchedUidForSession ? uid : '',
             searchedUid: uid,
             facility: facility as types.Facility,
             autoFill: null,
             prePopulateWithUID: prePopulateWithUID !== false,
             continueWithoutPrePopulation: true,
+            useSearchedUidForSession,
         }
         setConfirmNoRecord(false);
         if (onSession) onSession(initialSession);
         setMatched(initialSession);
-    }, [facility, onSession, prePopulateWithUID, setMatched, uid]);
+    }, [facility, onSession, prePopulateWithUID, setMatched, uid, useSearchedUidForSession]);
 
     const search = React.useCallback(() => {
         (async () => {
@@ -222,7 +241,7 @@ export function Search({ onSession, label, autofillKeys, filterEntries, prePopul
                     setConfirmNoRecord(true);
                     return;
                 }
-                if (prePopulateWithUID && !sessions?.length) {
+                if (!sessions?.length) {
                     setConfirmNoRecord(true);
                     return;
                 }
@@ -240,7 +259,7 @@ export function Search({ onSession, label, autofillKeys, filterEntries, prePopul
                 setSearching(false);
             }
         })();
-    }, [buildMatchedSession, onSession, prePopulateWithUID, qrSession, searchedFromQR, setMatched, uid]);
+    }, [buildMatchedSession, onSession, qrSession, searchedFromQR, setMatched, uid]);
 
 
 
@@ -248,7 +267,7 @@ export function Search({ onSession, label, autofillKeys, filterEntries, prePopul
     const neolabSessions = sessions?.filter(s => s?.data?.type === 'neolab' || getSessionTitle(s).match(/neolab/gi) || (s?.data?.script?.type === 'neolab'));
     const dischargeSessions = sessions?.filter(s => s?.data?.type === 'discharge' || getSessionTitle(s).match(/discharge/gi) || (s?.data?.script?.type === 'discharge'));
     const dailyRecordsSessions = sessions?.filter(s => s?.data?.type === 'drecord' || getSessionTitle(s).match(/daily record/gi) || (s?.data?.script?.type === 'drecord'));
-    const qrSessions = searchedFromQR && qrSession?.length ? qrSession : [];
+    const qrSessions = searchedFromQR ? (qrSessionRef.current?.length ? qrSessionRef.current : (qrSession?.length ? qrSession : [])) : [];
 
     function renderList(sessions: any[]) {
         return (
@@ -407,7 +426,7 @@ export function Search({ onSession, label, autofillKeys, filterEntries, prePopul
             <Modal
                 open={confirmNoRecord && !searching}
                 onClose={() => setConfirmNoRecord(false)}
-                title="No matching record found"
+                title={noRecordTitle}
                 actions={[
                     {
                         color: 'error',
@@ -426,7 +445,9 @@ export function Search({ onSession, label, autofillKeys, filterEntries, prePopul
                 ]}
             >
                 <Text color="textSecondary">
-                    {`No patient record was found for ${uid}. Continue without pre-population only if this is the correct Neotree ID. The script NUID will use the current Neotree ID.`}
+                    {noRecordMessage
+                        ? noRecordMessage(uid)
+                        : `No patient record was found for ${uid}. Continue without pre-population only if this is the correct Neotree ID. ${useSearchedUidForSession ? 'The script NUID will use the current Neotree ID.' : 'A new Neotree ID will be generated for this baby.'}`}
                 </Text>
             </Modal>
         </Box>

--- a/src/Home/Script/Start/Transfer.tsx
+++ b/src/Home/Script/Start/Transfer.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Box, Br, Radio, Text, } from '../../../components';
 import { Search } from './Search';
 
-type TransferProps = {
-
-};
-
-export function Transfer({}: TransferProps) {
+export function Transfer() {
     const [isTransferred, setIsTransferred] = React.useState<null | boolean>(null); 
 
     return (
@@ -42,6 +38,7 @@ export function Transfer({}: TransferProps) {
 					label="Search patient's NUID" 
 					autofillKeys={['BirthFacility', 'OtherBirthFacility']}
                     prePopulateWithUID={true}
+                    useSearchedUidForSession={true}
 				/>
 			)}
         </Box>

--- a/src/Home/Script/Start/Twin.tsx
+++ b/src/Home/Script/Start/Twin.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Box, Br, Radio, Text, } from '../../../components';
 import { Search } from './Search';
 
-type TwinProps = {
-
-};
-
-export function Twin({}: TwinProps) {
+export function Twin() {
     const [isTwin, setIsTwin] = React.useState<null | boolean>(null); 
 
     return (
@@ -42,6 +38,9 @@ export function Twin({}: TwinProps) {
 					label="Search patient's NUID" 
 					filterEntries={e => e.prePopulate && e.prePopulate.includes('twinSearches')}
 					prePopulateWithUID={false}
+                    useSearchedUidForSession={false}
+                    noRecordTitle="Twin record not found"
+                    noRecordMessage={uid => `No twin record was found for ${uid}. You can continue without twin pre-population. A new Neotree ID will be generated for this baby.`}
 				/>
 			)}
         </Box>

--- a/src/Home/Script/Start/field/index.tsx
+++ b/src/Home/Script/Start/field/index.tsx
@@ -13,6 +13,7 @@ export function Field({ field, value, onChange,script_type }: {
     onChange: (value: any) => void;
     script_type?:string
 }) {
+    const isTwinSearchField = field.key === 'BabyTwinNUID';
     const opts = (field.values || '').split('\n')
         .map((v = '') => v.trim())
         .filter((v: any) => v)
@@ -59,6 +60,11 @@ export function Field({ field, value, onChange,script_type }: {
                     <Search
                         label={field.label}
                         prePopulateWithUID={true}
+                        useSearchedUidForSession={!isTwinSearchField}
+                        noRecordTitle={isTwinSearchField ? 'Twin record not found' : undefined}
+                        noRecordMessage={isTwinSearchField
+                            ? (uid => `No twin record was found for ${uid}. You can continue without twin pre-population. A new Neotree ID will be generated for this baby.`)
+                            : undefined}
                         onSession={value => onChange(value)}
                         script_type={script_type}
                     />

--- a/src/Home/Script/Start/field/search.tsx
+++ b/src/Home/Script/Start/field/search.tsx
@@ -17,6 +17,9 @@ type SearchProps = {
     onSession: (data: null | types.MatchedSession) => void;
     filterEntries?: (entry: any) => any;
     script_type?: string;
+    useSearchedUidForSession?: boolean;
+    noRecordTitle?: string;
+    noRecordMessage?: (uid: string) => string;
 };
 
 const getSessionKey = (session: any, index?: number) => {
@@ -50,10 +53,15 @@ const hasFullQrSession = (session: any) => {
 
 const normalizeQrSession = (session: any) => {
     if (!hasFullQrSession(session)) return session;
-    if (session?.data) return session;
+    if (session?.data) {
+        return {
+            ...session,
+            uid: session.uid || session.data?.uid,
+        };
+    }
 
     return {
-        uid: session.uid,
+        uid: session.uid || session.data?.uid,
         data: {
             ...session,
             uid: session.uid,
@@ -84,7 +92,10 @@ export function Search({
     prePopulateWithUID,
     onSession,
     filterEntries,
-    script_type
+    script_type,
+    useSearchedUidForSession = prePopulateWithUID !== false,
+    noRecordTitle,
+    noRecordMessage,
 }: SearchProps) {
     const [uid, setUID] = React.useState('');
     const [sessions, setSessions] = React.useState<Awaited<ReturnType<typeof api.getLocalSessionsByUID>>>([]);
@@ -152,13 +163,14 @@ export function Search({
     const resolveUIDWithoutMatch = React.useCallback((nextUID: string) => {
         onSession({
             session: null,
-            uid: prePopulateWithUID === false ? '' : nextUID,
+            uid: useSearchedUidForSession ? nextUID : '',
             searchedUid: nextUID,
             autoFill: null,
             prePopulateWithUID: prePopulateWithUID !== false,
             continueWithoutPrePopulation: true,
+            useSearchedUidForSession,
         });
-    }, [onSession, prePopulateWithUID]);
+    }, [onSession, prePopulateWithUID, useSearchedUidForSession]);
 
     const filterSessionAutoFillEntries = React.useCallback((session: any) => {
         if (!session) return null;
@@ -200,8 +212,9 @@ export function Search({
             uid,
             autoFill: filterSessionAutoFillEntries(session),
             prePopulateWithUID: prePopulateWithUID !== false,
+            useSearchedUidForSession,
         };
-    }, [filterSessionAutoFillEntries, prePopulateWithUID, uid]);
+    }, [filterSessionAutoFillEntries, prePopulateWithUID, uid, useSearchedUidForSession]);
 
     const getRecommendedSession = React.useCallback((items: any[]) => {
         if (!items?.length) return null;
@@ -519,7 +532,9 @@ export function Search({
                 if (!rawSessions.length) {
                     setToClear(true);
                     setValidationMessage(
-                        `No patient record was found for ${uid}. Re-scan or continue without pre-population. The script NUID will use the current Neotree ID.`
+                        noRecordMessage
+                            ? noRecordMessage(uid)
+                            : `No patient record was found for ${uid}. Re-scan or continue without pre-population. ${useSearchedUidForSession ? 'The script NUID will use the current Neotree ID.' : 'A new Neotree ID will be generated for this baby.'}`
                     );
                     return;
                 }
@@ -555,7 +570,7 @@ export function Search({
             }
 
         })();
-    }, [buildMatchedSession, clearResolvedSearch, enforceNeolabView, getRecommendedSession, qrSession, script_type, searchedFromQR, uid]);
+    }, [buildMatchedSession, clearResolvedSearch, enforceNeolabView, getRecommendedSession, noRecordMessage, qrSession, script_type, searchedFromQR, uid, useSearchedUidForSession]);
 
 
     const handleYesPress = () => {
@@ -578,7 +593,7 @@ export function Search({
     const neolabSessions =merged.length>0?[]: sessions?.filter(s => s?.data?.type === 'neolab' || getSessionTitle(s).match(/neolab/gi) || (s.data?.script?.type === 'neolab'));
     const dischargeSessions =merged.length>0?[]:sessions?.filter(s => s?.data?.type === 'discharge' || getSessionTitle(s).match(/discharge/gi) || (s?.data?.script?.type === 'discharge'));
     const dailyRecordsSessions = merged.length>0?[]:sessions?.filter(s => s?.data?.type === 'drecord' || getSessionTitle(s).match(/daily record/gi) || (s?.data?.script?.type === 'drecord'));
-    const qrSessions = searchedFromQR && qrSession?.length ? qrSession : [];
+    const qrSessions = searchedFromQR ? (qrSessionRef.current?.length ? qrSessionRef.current : (qrSession?.length ? qrSession : [])) : [];
    
     function renderList(sessions: any[]) {
         return (
@@ -777,7 +792,7 @@ function hasPrePopulate(entry: any): boolean {
                                 <Modal
                                     open={toClear && !searching}
                                     onClose={() => { setToClear(false) }}
-                                    title="Continue With Current Neotree ID."
+                                    title={noRecordTitle || 'Continue Without Pre-Population'}
                                     actions={[
                                         {
                                             color: 'error',

--- a/src/contexts/script/index.tsx
+++ b/src/contexts/script/index.tsx
@@ -744,7 +744,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
 
         const searchedUIDSource = resolvedNuidSearchForm.find((f: types.NuidSearchFormField) => (
             f.results &&
-            f.results.prePopulateWithUID !== false &&
+            f.results.useSearchedUidForSession === true &&
             (f.value || f.results.uid || f.results.searchedUid)
         ));
         const searchedUID = searchedUIDSource?.value
@@ -752,7 +752,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
             || searchedUIDSource?.results?.searchedUid;
         const requiresSearchedUID = resolvedNuidSearchForm.some((f: types.NuidSearchFormField) => (
             f.results &&
-            f.results.prePopulateWithUID !== false
+            f.results.useSearchedUidForSession === true
         ));
 
         uid = searchedUID || uid;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type NuidSearchResults = {
     autoFill?: any; 
     prePopulateWithUID?: boolean;
     continueWithoutPrePopulation?: boolean;
+    useSearchedUidForSession?: boolean;
 };
 
 export type NuidSearchFormField = {
@@ -45,6 +46,7 @@ export type MatchedSession = {
 	autoFill?: any; 
 	prePopulateWithUID?: boolean;
 	continueWithoutPrePopulation?: boolean;
+	useSearchedUidForSession?: boolean;
     // fields: ({
     //     key: string;
     //     value: string;
@@ -67,7 +69,7 @@ export type Application = {
   };
 };
 export type Exception = {
-  id: Number,
+  id: number,
   device: string;
   message:string;
   hospital: string;


### PR DESCRIPTION
TICKET COMMENT : [TIM'S COMMENT](https://neotree.atlassian.net/browse/NEOAPP-1289?focusedCommentId=31691)

**Summary**

This PR refines twin-specific admission behavior so twin search can still pre-populate relevant data from an existing twin record without incorrectly reusing the searched twin’s Neotree ID for the new baby.

**Problem**

Twin search should not behave like transfer or readmission.

Previously, when a twin record was found, the searched twin’s Neotree ID could still flow into the new admission and be used as the current baby’s ID. That created the risk of assigning the sibling’s Neotree ID to the new twin admission instead of generating a fresh ID.

The intended behavior is:

- If a twin record is found, use it only to pre-populate twin-relevant fields.
- If no twin record is found, allow the user to continue without pre-population.
- In both cases, generate a new Neotree ID for the baby being admitted.