### PR TITLE
Updated eligibility inferred-screen skipping so it only applies after…

### DIFF
--- a/src/Home/Script/Start/index.tsx
+++ b/src/Home/Script/Start/index.tsx
@@ -14,7 +14,6 @@ export function Start() {
         setActiveScreen,
         saveSession,
         setActiveScreenIndex,
-        getScreen,
         screens, 
         matched, 
         script: { 
@@ -125,9 +124,8 @@ export function Start() {
 									try {
                                         setNuidSearchForm(fields);
 										await saveSession({ nuidSearchForm: fields });
-                                        const initial = getScreen({ direction: 'next', index: -1 }) || { screen: screens[0], index: 0 };
-										setActiveScreen(initial.screen);
-										setActiveScreenIndex(initial.index);
+										setActiveScreen(screens[0]);
+										setActiveScreenIndex(0);
 									} catch (error) {
                                         const message = error instanceof Error ? error.message : '';
                                         if (!message.includes('requires the searched Neotree ID')) {

--- a/src/contexts/script/index.tsx
+++ b/src/contexts/script/index.tsx
@@ -504,7 +504,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
                 return screenKey && `${v.key}`.toLowerCase() === `${screenKey}`.toLowerCase();
             });
 
-            if (inferredScreenEntry && direction) {
+            if (inferredScreenEntry && direction && index > 0) {
                 const res = getTargetScreen(index);
                 if (res) {
                     screen = res.screen;


### PR DESCRIPTION
**Summary**

Fixes the script start flow so the first screen is not skipped after starting a session.

**Changes**

- Restored `Start` to open `screens[0]` directly after saving the session.
- Removed the `getScreen({ direction: 'next', index: -1 })` call from the start button flow.
- Updated eligibility inferred-screen skipping so it only applies after the first screen.
- Preserved eligibility criteria auto-fill and inferred-screen skipping for later screens.

**Why**

The previous start flow used the general `getScreen` navigation resolver to determine the first active screen. That resolver applies screen conditions and eligibility inferred-screen skipping, which could cause screen index `0` to be skipped before the user ever saw it.
