### PR TITLE
• Add BID/StillBirth no-NUID start flow

### DIFF
--- a/src/Home/Script/Context.tsx
+++ b/src/Home/Script/Context.tsx
@@ -44,9 +44,11 @@ export type ContextType = ReturnType<typeof getScriptUtils> & {
     summary: any;
     matched: null | types.MatchedSession;
     mountedScreens: { [id: string]: boolean; };
-	patientDetails: PatientDetails;
+    patientDetails: PatientDetails;
     nuidSearchForm: types.NuidSearchFormField[];
+    startSessionMode: null | 'bidStillBirth';
     setNuidSearchForm: React.Dispatch<React.SetStateAction<types.NuidSearchFormField[]>>;
+    setStartSessionMode: React.Dispatch<React.SetStateAction<null | 'bidStillBirth'>>;
 	setPatientDetails: React.Dispatch<React.SetStateAction<PatientDetails>>;
 	saveSession: (params?: any) => Promise<any>;
 	createSummaryAndSaveSession: (params?: any) => Promise<any>;

--- a/src/Home/Script/Screen/_TypeForm/index.tsx
+++ b/src/Home/Script/Screen/_TypeForm/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { useScriptContext } from '@/src/contexts/script';
 import { parseFieldValues, parseFieldItems } from '@/src/utils/script-fields-and-items'; 
+import { filterFieldToBidStillBirthOptions } from '@/src/utils/bid-stillbirth-outcome';
 import {
     formatDateLikeLabel,
     isTimestampLabel,
@@ -31,6 +32,7 @@ export function TypeForm({ }: TypeFormProps) {
         activeScreenEntry,
         mountedScreens,
         nuidSearchForm,
+        startSessionMode,
         eligibilityAutoFillValues,
         evaluateCondition,
         parseCondition,
@@ -58,13 +60,22 @@ export function TypeForm({ }: TypeFormProps) {
     // Transform dropdown and multi_select fields to clear values if items is not empty
     const transformedFields = original.fields.map((field: any) => {
         const normalizedType = normalizeFieldType(field.type);
-        if ((normalizedType === "dropdown" || normalizedType === "multi_select") && Array.isArray(field.items) && field.items.length > 0) {
-            return {
-                ...field,
-                values: "",
-            };
+        const transformedField = (() => {
+            if ((normalizedType === "dropdown" || normalizedType === "multi_select") && Array.isArray(field.items) && field.items.length > 0) {
+                return {
+                    ...field,
+                    values: "",
+                };
+            }
+
+            return field;
+        })();
+
+        if (startSessionMode === 'bidStillBirth') {
+            return filterFieldToBidStillBirthOptions(transformedField);
         }
-        return field;
+
+        return transformedField;
     });
 
     if (!hasManual) {
@@ -116,7 +127,7 @@ export function TypeForm({ }: TypeFormProps) {
         ...original,
         fields: updatedFields,
     };
-}, [activeScreen?.data?.metadata, normalizeFieldType]);
+}, [activeScreen?.data?.metadata, normalizeFieldType, startSessionMode]);
 
     const cachedVal = activeScreenEntry?.values || [];
     const canAutoFill = !mountedScreens[activeScreen?.id];

--- a/src/Home/Script/Start/index.tsx
+++ b/src/Home/Script/Start/index.tsx
@@ -2,15 +2,31 @@ import React, { Fragment, useState } from 'react';
 import { Alert, Keyboard, ScrollView } from 'react-native';
 
 import { useScriptContext } from '@/src/contexts/script';
+import { hasBidStillBirthOutcomeOptions } from '@/src/utils/bid-stillbirth-outcome';
 import { Box, Button, Content, Text } from '../../../components';
 import { Field } from './field';
 import * as types from '../../../types';
+
+function isStandardNuidSearchField(field: any) {
+    const key = `${field?.key ?? ''}`.toLowerCase();
+    const label = `${field?.label ?? ''}`.toLowerCase();
+
+    return field?.type === 'text'
+        && !key.includes('twin')
+        && !label.includes('twin')
+        && !key.includes('transfer')
+        && !key.includes('transfered')
+        && !key.includes('transferred')
+        && !label.includes('transfer')
+        && !label.includes('transferred');
+}
 
 export function Start() {
     const { 
         evaluateCondition,
         parseCondition,
         setNuidSearchForm,
+        setStartSessionMode,
         setActiveScreen,
         saveSession,
         setActiveScreenIndex,
@@ -26,6 +42,7 @@ export function Start() {
 
 
     const [keyboardIsOpen, setKeyboardIsOpen] = React.useState(false);
+    const [starting, setStarting] = React.useState(false);
 
     const [fields, setFields] = useState<types.NuidSearchFormField[]>(nuidSearchFields.map((f: any) => ({
         key: f.key,
@@ -35,12 +52,12 @@ export function Start() {
         results: null,
     })));
 
-    const evaluateFieldCondition = (f: any) => {
+    const evaluateFieldCondition = React.useCallback((f: any) => {
         let conditionMet = true;
         const values = fields;
         if (f.condition) conditionMet = evaluateCondition(parseCondition(f.condition, [{ values }])) as boolean;
         return conditionMet;
-    };
+    }, [evaluateCondition, fields, parseCondition]);
 
     React.useEffect(() => {
         const keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', () => setKeyboardIsOpen(true));
@@ -58,6 +75,69 @@ export function Start() {
     });
 
     const canStart = Boolean(screens?.length) && hasResolvedVisibleSearchFields;
+    const canStartWithoutNuid = Boolean(screens?.length) && nuidSearchFields.some((field: any) => (
+        isStandardNuidSearchField(field) && evaluateFieldCondition(field)
+    ));
+
+    const startSession = React.useCallback(async (
+        nextFields: types.NuidSearchFormField[],
+        nextStartSessionMode: null | 'bidStillBirth' = null
+    ) => {
+        try {
+            setStarting(true);
+            setNuidSearchForm(nextFields);
+            setStartSessionMode(nextStartSessionMode);
+            await saveSession({
+                nuidSearchForm: nextFields,
+                startSessionMode: nextStartSessionMode,
+            });
+            setActiveScreen(screens[0]);
+            setActiveScreenIndex(0);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : '';
+            if (!message.includes('requires the searched Neotree ID')) {
+                Alert.alert(
+                    'Unable to start session',
+                    message
+                        ? `The session could not be started because: ${message}`
+                        : 'The session could not be started. Please check the form setup and try again.'
+                );
+            }
+        } finally {
+            setStarting(false);
+        }
+    }, [saveSession, screens, setActiveScreen, setActiveScreenIndex, setNuidSearchForm, setStartSessionMode]);
+
+    const startSessionWithoutNuid = React.useCallback(() => {
+        if (!hasBidStillBirthOutcomeOptions(screens)) {
+            Alert.alert(
+                'BID/StillBirth outcome unavailable',
+                'The current script does not have any NeoTreeOutcome options related to BID or StillBirth.'
+            );
+            return;
+        }
+
+        const nextFields = fields.map((field, i) => {
+            const searchField = nuidSearchFields[i];
+            if (!isStandardNuidSearchField(searchField) || !evaluateFieldCondition(searchField)) return field;
+
+            return {
+                ...field,
+                value: null,
+                results: {
+                    session: null,
+                    uid: '',
+                    searchedUid: '',
+                    prePopulateWithUID: false,
+                    continueWithoutPrePopulation: true,
+                    useSearchedUidForSession: false,
+                },
+            };
+        });
+
+        setFields(nextFields);
+        startSession(nextFields, 'bidStillBirth');
+    }, [evaluateFieldCondition, fields, nuidSearchFields, screens, startSession]);
 
     return (
         <Box flex={1} paddingTop="xl">
@@ -118,26 +198,20 @@ export function Start() {
                         )}
 
                         <Button
-                            disabled={!canStart}
-                            onPress={() => {
-                                (async () => {
-									try {
-                                        setNuidSearchForm(fields);
-										await saveSession({ nuidSearchForm: fields });
-										setActiveScreen(screens[0]);
-										setActiveScreenIndex(0);
-									} catch (error) {
-                                        const message = error instanceof Error ? error.message : '';
-                                        if (!message.includes('requires the searched Neotree ID')) {
-                                            Alert.alert(
-                                                'Unable to start session',
-                                                'The session could not be saved. Please try again before continuing.'
-                                            );
-                                        }
-                                    }
-								})();
-                            }}
+                            disabled={!canStart || starting}
+                            onPress={() => startSession(fields)}
                         >{matched?.session ? 'Continue' : 'Start'}</Button>
+
+                        {canStartWithoutNuid ? (
+                            <>
+                                <Box marginVertical="s" />
+                                <Button
+                                    color="secondary"
+                                    disabled={starting || !screens?.length}
+                                    onPress={startSessionWithoutNuid}
+                                >BID/StillBirth</Button>
+                            </>
+                        ) : null}
                     </Content>
                 </Box>
             )}

--- a/src/contexts/script/index.tsx
+++ b/src/contexts/script/index.tsx
@@ -100,6 +100,9 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
 
     const [loadingScreen, setLoadingScreen] = useState(false);
     const [nuidSearchForm, setNuidSearchForm] = useState<types.NuidSearchFormField[]>([]);
+    const [startSessionMode, setStartSessionMode] = useState<null | 'bidStillBirth'>(
+        route.params?.session?.data?.startSessionMode || null
+    );
     const [eligibilityCompleted, setEligibilityCompleted] = useState(Boolean(route.params?.session?.data?.eligibilityCompleted));
     const [eligibilityAutoFillValues, setEligibilityAutoFillValues] = useState<types.ScreenEntryValue[]>(
         route.params?.session?.data?.eligibilityAutoFillValues || []
@@ -794,12 +797,20 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
       }, [entries]);
 
     const createSessionSummary = useCallback((_payload: any = {}) => {    
-        const { completed, cancelled, dateAndTimeOfDeath, nuidSearchForm: payloadNuidSearchForm, ...payload } = _payload;
+        const {
+            completed,
+            cancelled,
+            dateAndTimeOfDeath,
+            nuidSearchForm: payloadNuidSearchForm,
+            startSessionMode: payloadStartSessionMode,
+            ...payload
+        } = _payload;
 
         const matchingSession = matched?.session || null;
 		const session = route.params?.session;
         const matches: any[] = [];
         const resolvedNuidSearchForm = payloadNuidSearchForm || nuidSearchForm;
+        const resolvedStartSessionMode = payloadStartSessionMode ?? startSessionMode;
 
         let uid = entries.reduce((acc, { values }) => {
             const uid = values.reduce((acc, { key, value }) => {
@@ -844,6 +855,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
                 dateAndTimeOfDeath,
 				unique_key: `${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}`,
 				app_mode: application?.mode,
+                startSessionMode: resolvedStartSessionMode,
 				country: location?.country,
 				hospital_id: location?.hospital,
 				started_at: session?.data?.started_at || startTime,
@@ -883,6 +895,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
         location,
         screens,
         script,
+        startSessionMode,
         restructureForm,
         nuidSearchForm,
         eligibilityCompleted,
@@ -1353,6 +1366,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
         startTime,
         refresh,
         nuidSearchForm,
+        startSessionMode,
         eligibilityCompleted,
         eligibilityAutoFillValues,
         matched,
@@ -1390,6 +1404,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
         setMoreNavOptions,
         setRefresh,
         setNuidSearchForm,
+        setStartSessionMode,
         setEligibilityCompleted,
         setEligibilityAutoFillValues,
         setMatched,

--- a/src/utils/bid-stillbirth-outcome.ts
+++ b/src/utils/bid-stillbirth-outcome.ts
@@ -1,0 +1,69 @@
+import { parseFieldItems, parseFieldValues } from './script-fields-and-items';
+
+type FieldOption = ReturnType<typeof parseFieldItems>[number];
+
+const OUTCOME_KEY = 'neotreeoutcome';
+
+export function isNeoTreeOutcomeField(field: any) {
+    return `${field?.key ?? ''}`.trim().toLowerCase() === OUTCOME_KEY;
+}
+
+export function isBidStillBirthOutcomeOption(option: Partial<FieldOption>) {
+    const text = `${option?.label ?? ''} ${option?.value ?? ''}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+
+    return /\bbid\b/.test(text)
+        || text.includes('brought in dead')
+        || text.includes('still birth')
+        || text.includes('stillbirth');
+}
+
+export function getFieldOptions(field: any): FieldOption[] {
+    if (!field?.items) {
+        return parseFieldValues({
+            values: field?.values,
+            options: field?.valuesOptions,
+        });
+    }
+
+    return parseFieldItems({ items: field.items });
+}
+
+export function getBidStillBirthOutcomeOptions(field: any) {
+    return getFieldOptions(field).filter(isBidStillBirthOutcomeOption);
+}
+
+export function hasBidStillBirthOutcomeOptions(screens: any[] = []) {
+    return screens.some(screen => (
+        screen?.data?.metadata?.fields || []
+    ).some((field: any) => (
+        isNeoTreeOutcomeField(field) && getBidStillBirthOutcomeOptions(field).length > 0
+    )));
+}
+
+export function filterFieldToBidStillBirthOptions(field: any) {
+    if (!isNeoTreeOutcomeField(field)) return field;
+
+    if (Array.isArray(field?.items)) {
+        return {
+            ...field,
+            items: field.items.filter((item: any) => isBidStillBirthOutcomeOption(item)),
+        };
+    }
+
+    const values = `${field?.values ?? ''}`.split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+        .filter(line => {
+            const [value, label] = line.split(',');
+            return isBidStillBirthOutcomeOption({ value, label });
+        })
+        .join('\n');
+
+    return {
+        ...field,
+        values,
+    };
+}


### PR DESCRIPTION
  - Add BID/StillBirth start button for standard NUID search screens only
  - Exclude Twin and Transfer NUID search flows from the special no-NUID path
  - Start BID/StillBirth sessions with autogenerated UID and no pre-population
  - Persist special start mode so resumed sessions keep the same restrictions
  - Restrict NeoTreeOutcome options to BID, Brought in dead, or StillBirth matches if started in BID/StillBirth mode
  - Warn users when the script has no BID/StillBirth-compatible outcome options
  - Improve start-session failure alert to show the underlying error message