### PR TITLE
Fix duplicate session exports + offline export hardening

### DIFF
--- a/src/Home/Sessions/export/index.ts
+++ b/src/Home/Sessions/export/index.ts
@@ -267,7 +267,7 @@ export function exportToApi(opts: any = {}) {
           }
         }
 
-        const sessions = [
+        const candidates = [
           ..._sessions,
           ...queuedSessions,
         ]
@@ -281,10 +281,28 @@ export function exportToApi(opts: any = {}) {
           if (opts.dontSaveFile !== true) await exportJSON(opts);
         } catch (e) { /* Do nothing */ }
 
-        if (!sessions.length) {
+        if (!candidates.length) {
           resolve(null);
           return;
         }
+
+        await api.withExportLock(async () => {
+
+        // Refresh export flags from the db: an auto-export may have finished
+        // while this run waited for the lock, or the screen state may be stale
+        const freshRows: any[] = ((await api.getSessions()) as any[]) || [];
+        const freshById: any = {};
+        freshRows.forEach((s: any) => { if (s?.id !== undefined) freshById[s.id] = s; });
+
+        const sessions = candidates
+          .map((s: any) => !freshById[s?.id] ? s : {
+            ...s,
+            exported: freshById[s.id].exported,
+            local_export: freshById[s.id].local_export,
+          })
+          .filter((s: any) => s && !s.exported);
+
+        if (!sessions.length) return;
 
         // Get location config once for all operations
         const location = await api.getLocation();
@@ -403,6 +421,8 @@ export function exportToApi(opts: any = {}) {
         if (mainSuccessIds.length > 0) {
           await removeFromExportQueue(mainSuccessIds);
         }
+
+        });
 
         resolve(null);
       } catch (e) {

--- a/src/contexts/script/index.tsx
+++ b/src/contexts/script/index.tsx
@@ -879,7 +879,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
             type: script?.type,
             data: {
                 dateAndTimeOfDeath,
-				unique_key: `${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}`,
+				unique_key: session?.data?.unique_key || summary?.data?.unique_key || `${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}${Math.random().toString(36).substring(2)}`,
 				app_mode: application?.mode,
                 startSessionMode: resolvedStartSessionMode,
 				country: location?.country,
@@ -926,6 +926,7 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
         nuidSearchForm,
         eligibilityCompleted,
         eligibilityAutoFillValues,
+        summary,
     ]);
 
     const getScreenIndex = useCallback((screenId: string | number) => {
@@ -957,7 +958,6 @@ function useScriptContextValue(props: ScriptContextProviderProps) {
         (async () => {
             try {
                 const summary = await saveSession(params);
-                api.exportSessions().then(() => { }).catch(() => { });
                 setSummary(summary);
                 resolve(summary);
             } catch (e) {

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -38,38 +38,24 @@ export async function makeApiCall(
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 300000);
 
-        const method = options?.method?.toUpperCase() || 'GET';
-
         try {
-            if(method==='GET') {
-                const res = await fetch(url, {
-                    ...options,
-                    signal: controller.signal,
-                    headers: {
-                        'Content-Type': 'application/json',
-                        ...options.headers,
-                        'x-api-key': config.api_key,
-                    },
-                });
-                clearTimeout(timeout);
-                return res;
-            } else {
-                const res = await fetch(url, {
-                    ...options,
-                    headers: {
-                        'Content-Type': 'application/json',
-                        ...options.headers,
-                        'x-api-key': config.api_key,
-                    },
-                });
-                clearTimeout(timeout);
-                return res;
-            }
+            const res = await fetch(url, {
+                ...options,
+                signal: controller.signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...options.headers,
+                    'x-api-key': config.api_key,
+                },
+            });
+            return res;
         } catch(err:any) {
             if (err.name === 'AbortError') {
-                throw new Error('Network Request Taking Too Longer than the expected 45 Seconds!!');
+                throw new Error('Network request timed out after 5 minutes. Check your connection and try again.');
             }
             throw err;
+        } finally {
+            clearTimeout(timeout);
         }
     } catch(e) {
         // if (process.env.APP_ENV !== 'PROD') console.error(`[ERROR]: ${url}`, e);
@@ -102,20 +88,34 @@ export async function makeLocalApiCall(
     
        const sec = config?.[0].secret
         const body =encryptInReactNative(options.body, sec);
-        const res = await fetch(url, {
-            method:'POST',
-            body: JSON.stringify({data:body}),
-            headers: {
-                'Content-Type': 'application/json',
-                ...options.headers,
-                'x-api-key': config?.[0].api_key,
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 30000);
+
+        let res;
+        try {
+            res = await fetch(url, {
+                method:'POST',
+                body: JSON.stringify({data:body}),
+                signal: controller.signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...options.headers,
+                    'x-api-key': config?.[0].api_key,
+                }
+            });
+        } catch (err: any) {
+            if (err.name === 'AbortError') {
+                throw new Error('Local Server Connection Taking Longer Than The Expected 30 Seconds. Check With The Administrator if it is up!!');
             }
-        });
+            throw err;
+        } finally {
+            clearTimeout(timeout);
+        }
 
         if (res.status !== 200) {
             console.log(res);
         }
-       
 
         return res;
     }

--- a/src/data/exportLock.ts
+++ b/src/data/exportLock.ts
@@ -1,0 +1,13 @@
+let chain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Serializes session exports so overlapping triggers (auto-export after saving
+ * a session, manual export from the Sessions screen) can never POST the same
+ * session concurrently. Queued runs re-read the exported flags from the local
+ * db, so a session exported by an earlier run becomes a no-op in the next one.
+ */
+export function withExportLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = chain.then(fn);
+    chain = run.then(() => undefined, () => undefined);
+    return run;
+}

--- a/src/data/exportOnReconnect.ts
+++ b/src/data/exportOnReconnect.ts
@@ -1,0 +1,49 @@
+import { InteractionManager } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
+
+import { exportSessions } from './exportSessions';
+
+let unsubscribe: (() => void) | null = null;
+let wasOnline: boolean | null = null;
+let flushPending = false;
+
+/**
+ * Runs completely silently: waits for any in-progress animations/gestures
+ * before doing work, swallows every error, and never touches the UI. At most
+ * one flush is pending at a time, so a flapping network can't pile up runs.
+ */
+function queueSilentFlush() {
+    if (flushPending) return;
+    flushPending = true;
+
+    InteractionManager.runAfterInteractions(() => {
+        const clear = () => { flushPending = false; };
+        exportSessions().then(clear, clear);
+    });
+}
+
+/**
+ * Flushes unexported sessions as soon as connectivity is restored, so sessions
+ * completed offline don't wait for the next session save or a manual export.
+ * Safe to call more than once — only one listener is ever registered, and
+ * overlapping flushes are serialized by the export lock.
+ */
+export function registerExportOnReconnect() {
+    if (unsubscribe) return unsubscribe;
+
+    const removeListener = NetInfo.addEventListener(state => {
+        const online = Boolean(state.isConnected && state.isInternetReachable);
+        const cameBackOnline = wasOnline === false && online;
+        wasOnline = online;
+
+        if (cameBackOnline) queueSilentFlush();
+    });
+
+    unsubscribe = () => {
+        removeListener();
+        unsubscribe = null;
+        wasOnline = null;
+    };
+
+    return unsubscribe;
+}

--- a/src/data/exportSessions.ts
+++ b/src/data/exportSessions.ts
@@ -1,19 +1,26 @@
 import { dbTransaction } from './db';
 import { convertSessionsToExportable } from './convertSessionsToExportable';
-import { makeApiCall, makeLocalApiCall } from './api';
+import { makeApiCall, makeLocalApiCall, hasLocalServerConfig } from './api';
 import { updateSession } from './updateSession';
-import { APP_CONFIG } from '@/src/constants';
-import * as types from '../types';
-import { getLocation } from './queries';
+import { withExportLock } from './exportLock';
 
-export const exportSessions = (sessions?: any[]) => new Promise((resolve, reject) => {
+const doExportSessions = (sessions?: any[]) => new Promise((resolve, reject) => {
     (async () => {
         try {
-			let dbSessions = [];
-        
-            if (!sessions) dbSessions = await dbTransaction('SELECT * FROM sessions WHERE exported IS NOT ? OR local_export IS NOT ?;',[true, true]);
+            const hasLocalConfig = await hasLocalServerConfig();
 
-        
+			let dbSessions = [];
+
+            // only local-server sites track local_export; querying it at other
+            // sites would rescan every exported session forever
+            if (!sessions) dbSessions = await dbTransaction(
+                hasLocalConfig
+                    ? 'SELECT * FROM sessions WHERE exported IS NOT ? OR local_export IS NOT ?;'
+                    : 'SELECT * FROM sessions WHERE exported IS NOT ?;',
+                hasLocalConfig ? [true, true] : [true]
+            );
+
+
             const promises: Promise<any>[] = [];
             const exportableDbSessions = dbSessions.map(s => ({ ...s, data: JSON.parse(s.data || '{}'), })).filter(s => s.data.completed_at || s.data.canceled_at);
             const exportData: any[] = sessions || exportableDbSessions.filter(s => s.data.completed_at && !s.exported);
@@ -51,18 +58,6 @@ export const exportSessions = (sessions?: any[]) => new Promise((resolve, reject
                     })();
                 })));
             }
-              const location = await getLocation();
-               const country =  location?.country;
-               let hasLocalConfig = false
-              if(country && country.length>0){
-                 const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)['local'];
-                 const hospital = location?.hospital
-                 const localConfig = config?.filter(c=>c.hospital===hospital?.trim())
-                 if(localConfig && localConfig?.[0]?.hospital?.length>0){
-                     hasLocalConfig =true 
-                 }
-            }
-
             // Handle /local calls (only if hasLocalConfig)
             if (exportData.length && hasLocalConfig) {
                 const localData: any = await convertSessionsToExportable(exportData, { showConfidential: true, });
@@ -115,8 +110,10 @@ export const exportSessions = (sessions?: any[]) => new Promise((resolve, reject
             if (failed.length) throw new Error('Failed to export session, try again!');
 
             resolve(null);
-        } catch (e) { 
-            reject(e); 
+        } catch (e) {
+            reject(e);
         }
     })();
 });
+
+export const exportSessions = (sessions?: any[]) => withExportLock(() => doExportSessions(sessions));

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -10,6 +10,10 @@ export * from './convertSessionsToExportable';
 
 export * from './exportSessions';
 
+export * from './exportLock';
+
+export * from './exportOnReconnect';
+
 export * from './saveSession';
 
 export * from './updateSession';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { StatusBar } from 'expo-status-bar';
 import registerdAssets from './assets';
 import { Authentication } from './Authentication';
 import { HomeNavigator } from './Home';
-import { syncData, addSocketEventsListeners } from './data';
+import { syncData, addSocketEventsListeners, registerExportOnReconnect } from './data';
 import { useAppContext } from './AppContext';
 import { Splash } from './components';
 import { SyncStatus } from './components/sync-status';
@@ -33,12 +33,11 @@ export function Navigation() {
 
     React.useEffect(() => { if (!ready) initialiseApp(); }, [ready]);
 
-    React.useEffect(() => { 
-        
-        addSocketEventsListeners(initialiseApp)
-    
-      
-        ; }, []);
+    React.useEffect(() => {
+        addSocketEventsListeners(initialiseApp);
+        const unsubscribe = registerExportOnReconnect();
+        return unsubscribe;
+    }, []);
       
 
     if (!ready) return <Splash />;


### PR DESCRIPTION
This PR is for Ticket: [NEOAPP1397](https://neotree.atlassian.net/browse/NEOAPP-1397)

## Fix duplicate session exports + offline export hardening

### Bug fix
Sessions were being duplicated in `public.sessions` (same `uid`, rows inserted milliseconds apart). Root cause: on completion the app fired `exportSessions()` twice, once inside `api.saveSession` and again in `createSummaryAndSaveSession`, producing two concurrent POSTs that both passed the API's non-atomic `unique_key` check.

- Removed the redundant export trigger in the script context
- Added an export lock (`data/exportLock.ts`) so export runs are serialized, overlapping triggers (auto, manual, reconnect) can never post the same session twice
- Manual export (Sessions screen) now runs under the same lock and re-reads fresh `exported`/`local_export` flags from the DB before posting
- `unique_key` is now preserved across re-saves of a session instead of being regenerated, so the server can dedupe retries

### Enhancements
- **Auto-flush on reconnect** (`data/exportOnReconnect.ts`): unexported sessions upload as soon as connectivity returns — silent, deferred behind `InteractionManager` so it never interrupts the UI, deduped against network flapping
- **Request timeouts**: abort signal now attached to POSTs in `makeApiCall` (was GET-only, so hung uploads could stall forever); `makeLocalApiCall` POSTs get a 30s timeout (had none)
- **Non-local-site optimization**: the export query only checks `local_export` at sites with a local server configured, preventing an ever-growing rescan of exported sessions at all other sites

### Notes
- Server-side fix still required for full protection: `UNIQUE` constraint on `unique_key` + `ON CONFLICT` upsert in the node API, plus cleanup of existing duplicate rows
