### PR TITLE
circuit breaker implementation incase local or remote server is down

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -8,6 +8,8 @@ export interface IAppContext {
     setAuthenticatedUser: React.Dispatch<React.SetStateAction<types.AuthenticatedUser | null>>;    
     setApplication: React.Dispatch<React.SetStateAction<types.Application | null>>;
     setSyncDataResponse: (res: Awaited<ReturnType<typeof api.syncData>>) => void;
+    locationVersion: number;
+    bumpLocationVersion: () => void;
 }
 
 export const AppContext = React.createContext<IAppContext>(null!);
@@ -17,6 +19,7 @@ export const useAppContext = () => React.useContext(AppContext);
 export function AppContextProvider({ children }: React.PropsWithChildren<{}>) {
     const [authenticatedUser, setAuthenticatedUser] = React.useState<types.AuthenticatedUser | null>(null);
     const [application, setApplication] = React.useState<types.Application | null>(null);
+    const [locationVersion, setLocationVersion] = React.useState(0);
 
     return (
         <AppContext.Provider 
@@ -29,6 +32,8 @@ export function AppContextProvider({ children }: React.PropsWithChildren<{}>) {
                     setAuthenticatedUser(res?.authenticatedUser);
                     setApplication(res?.application);
                 },
+                locationVersion,
+                bumpLocationVersion: () => setLocationVersion(v => v + 1),
             }}
         >
             {children}

--- a/src/Authentication/index.tsx
+++ b/src/Authentication/index.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import { View, Image } from "react-native";
 import assets from "../assets";
 import { Content, Box, LocationForm  } from "../components";
+import { useAppContext } from '../AppContext';
 import { SignIn } from './SignIn';
 
 type AuthenticationProps = {};
 
 export function Authentication({}: AuthenticationProps) {
     const [section, setSection] = React.useState<'location' | 'sign-in'>('location');
+    const { bumpLocationVersion } = useAppContext() || {};
 
     const onSetLocation = React.useCallback(() => {
+        bumpLocationVersion && bumpLocationVersion();
         setSection('sign-in');
-    }, []);
+    }, [bumpLocationVersion]);
 
     const onSignIn = React.useCallback(() => {
 

--- a/src/Home/Account/index.tsx
+++ b/src/Home/Account/index.tsx
@@ -93,6 +93,7 @@ export function Account() {
                                         (async () => {
                                             setDisplayLoader(true);
                                             await api.resetApp();
+                                            api.invalidateLocationCache();
                                             await api.logout();
                                             setDisplayLoader(false);
                                             setAuthenticatedUser && setAuthenticatedUser(null);

--- a/src/Home/Location/index.tsx
+++ b/src/Home/Location/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, TouchableOpacity, Platform } from "react-native";
+import { ScrollView, TouchableOpacity, Platform, Alert } from "react-native";
 import Icon from '@expo/vector-icons/MaterialIcons';
 import { useAppContext } from '../../AppContext';
 import { Content, LocationForm, OverlayLoader, Box } from "../../components";
@@ -7,7 +7,7 @@ import * as api from '../../data';
 import * as types from '../../types';
 
 export function Location({ navigation }: types.StackNavigationProps<types.HomeRoutes, 'Location'>) {
-	const {setSyncDataResponse} = useAppContext();
+	const {setSyncDataResponse, bumpLocationVersion} = useAppContext();
 	const [displayLoader, setDisplayLoader] = React.useState(false);
 
 
@@ -33,11 +33,22 @@ export function Location({ navigation }: types.StackNavigationProps<types.HomeRo
 				<Content>
 					<LocationForm 
 						onSetLocation={() => {
+							bumpLocationVersion && bumpLocationVersion();
 							(async () => {
 								setDisplayLoader(true);
-								const res = await api.syncData({ force: true, });
-								setSyncDataResponse && setSyncDataResponse(res);
-								setDisplayLoader(false);
+								try {
+									const res = await api.syncData({ force: true, });
+									setSyncDataResponse && setSyncDataResponse(res);
+								} catch (e) {
+									console.log('Location syncData', e);
+									Alert.alert(
+										'Sync failed',
+										'Please try again once you have a connection.',
+										[{ text: 'OK' }],
+									);
+								} finally {
+									setDisplayLoader(false);
+								}
 							})();
 						}}
 					/>

--- a/src/Home/Sessions/export/getJSON.ts
+++ b/src/Home/Sessions/export/getJSON.ts
@@ -1,10 +1,10 @@
 import { APP_VERSION } from '@/src/constants';
-import { convertSessionsToExportable } from '../../../data';
+import { convertSessionsToExportable, isExportableSession } from '../../../data';
 
 export default function getJSON(opts: any = {}) {
   const { showConfidential, sessions: _sessions, application } = opts;
 
-  const sessions = (_sessions || []).map((s: any) => {
+  const sessions = (_sessions || []).filter(isExportableSession).map((s: any) => {
     const { script, app_mode, country, hospital_id, started_at, completed_at, canceled_at } = s.data;
     const { entries, diagnoses }: any = convertSessionsToExportable([s], { showConfidential });
 

--- a/src/Home/Sessions/export/index.ts
+++ b/src/Home/Sessions/export/index.ts
@@ -5,11 +5,18 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as api from '../../../data';
 import moment from 'moment';
 import getJSON from './getJSON';
-import { APP_CONFIG } from '../../../constants';
-import * as types from '../../../types';
 import { ASYNC_STORAGE_KEYS } from '../../../constants/async-storage';
 
 export { getJSON };
+export interface ManualExportOutcome {
+  status: 'success' | 'already-exported' | 'local-only' | 'partial' | 'failed';
+  localConfigured: boolean;
+  localOk: number;
+  remoteOk: number;
+  localPending: number;
+  remotePending: number;
+  alreadyExported: number;
+}
 
 const getDate = () => moment(new Date()).format('YYYYMMDDhmm');
 
@@ -87,7 +94,8 @@ const isSavingToDevicePermitted = () => new Promise((resolve, reject) => {
 });
 
 export function exportJSON(_opts: any = {}) {
-  const { sessions, ...opts } = _opts;
+  const { sessions: suppliedSessions, ...opts } = _opts;
+  const sessions = (suppliedSessions || []).filter(api.isExportableSession);
 
   return new Promise((resolve, reject) => {
     (async () => {
@@ -130,7 +138,7 @@ export function exportJSON(_opts: any = {}) {
 }
 
 export function exportEXCEL(opts: any = {}) {
-  const sessions = opts.sessions || [];
+  const sessions = (opts.sessions || []).filter(api.isExportableSession);
   const scriptsFields = { ...opts.scriptsFields };
 
   return new Promise((resolve, reject) => {
@@ -250,7 +258,7 @@ export function exportEXCEL(opts: any = {}) {
 }
 
 export function exportToApi(opts: any = {}) {
-  const _sessions = opts.sessions || [];
+  const _sessions = (opts.sessions || []).filter(api.isExportableSession);
 
   return new Promise((resolve, reject) => {
     (async () => {
@@ -265,13 +273,38 @@ export function exportToApi(opts: any = {}) {
           if (missingIds.length) {
             await removeFromExportQueue(missingIds);
           }
+
+          const nonExportableIds = queuedSessions
+            .filter(s => !api.isExportableSession(s))
+            .map(s => s.id);
+          if (nonExportableIds.length) {
+            await removeFromExportQueue(nonExportableIds);
+            queuedSessions = queuedSessions.filter(api.isExportableSession);
+          }
+
+          const alreadyExportedIds = queuedSessions.filter(s => Boolean(s.exported)).map(s => s.id);
+          if (alreadyExportedIds.length) {
+            await removeFromExportQueue(alreadyExportedIds);
+            queuedSessions = queuedSessions.filter(s => !Boolean(s.exported));
+          }
         }
+
+        const hasLocalConfig = await api.hasLocalServerConfig();
+        const location = await api.getLocation();
+
+        const localRequired = (s: any) => api.localRequiredForSession(s, location, hasLocalConfig);
+
+        const needsExport = (s: any) => api.isExportableSession(s) && (
+          !s.exported ||
+          (api.pollingRequired(s.data?.country) && !s.poll_exported) ||
+          (localRequired(s) && !s.local_export)
+        );
 
         const candidates = [
           ..._sessions,
           ...queuedSessions,
         ]
-          .filter((s: any) => s && !s.exported)
+          .filter(needsExport)
           .reduce((acc: any[], s: any) => {
             if (!acc.some(e => e.id === s.id)) acc.push(s);
             return acc;
@@ -279,17 +312,36 @@ export function exportToApi(opts: any = {}) {
 
         try {
           if (opts.dontSaveFile !== true) await exportJSON(opts);
-        } catch (e) { /* Do nothing */ }
+        } catch { /* Do nothing */ }
+
+        let outcome: ManualExportOutcome = {
+          status: 'success',
+          localConfigured: hasLocalConfig,
+          localOk: 0,
+          remoteOk: 0,
+          localPending: 0,
+          remotePending: 0,
+          alreadyExported: 0,
+        };
 
         if (!candidates.length) {
-          resolve(null);
+          const selectedCount = Array.isArray(_sessions) ? _sessions.length : 0;
+          if (selectedCount) {
+            outcome = { ...outcome, status: 'already-exported', alreadyExported: selectedCount };
+          }
+          resolve(outcome);
           return;
         }
 
+        try {
+          const loc = await api.getLocation();
+          if (loc?.country) {
+            api.resetCircuit(api.backendKey(loc.country, 'local', loc.hospital));
+          }
+        } catch { /* a failed location read just means no local reset */ }
+
         await api.withExportLock(async () => {
 
-        // Refresh export flags from the db: an auto-export may have finished
-        // while this run waited for the lock, or the screen state may be stale
         const freshRows: any[] = ((await api.getSessions()) as any[]) || [];
         const freshById: any = {};
         freshRows.forEach((s: any) => { if (s?.id !== undefined) freshById[s.id] = s; });
@@ -298,133 +350,107 @@ export function exportToApi(opts: any = {}) {
           .map((s: any) => !freshById[s?.id] ? s : {
             ...s,
             exported: freshById[s.id].exported,
+            poll_exported: freshById[s.id].poll_exported,
             local_export: freshById[s.id].local_export,
           })
-          .filter((s: any) => s && !s.exported);
+          .filter(needsExport);
 
         if (!sessions.length) return;
 
-        // Get location config once for all operations
-        const location = await api.getLocation();
-        const country = location?.country;
-        const hasLocalConfig = Boolean(
-          country &&
-          country.length > 0 &&
-          (() => {
-            const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)['local'];
-            const hospital = location?.hospital;
-            const localConfig = config?.filter(c => c.hospital === hospital?.trim());
-            return localConfig?.[0]?.hospital?.length > 0;
-          })()
+        const wasRemoteDone = new Set(
+          sessions
+            .filter((s: any) => {
+              const pollSatisfied = !api.pollingRequired(s.data?.country) || Boolean(s.poll_exported);
+              return Boolean(s.exported) && pollSatisfied;
+            })
+            .map((s: any) => s.id)
         );
 
-        // Convert sessions once for standard export, once for poll/local data
-        const [standardExportData, pollExportData] = await Promise.all([
-          api.convertSessionsToExportable(sessions, opts),
-          api.convertSessionsToExportable(sessions, { ...opts, showConfidential: true })
-        ]) as [any[], any[]];
-
-        // Three independent API call groups
-        const apiCallGroups = [
-          // 1. Main session export to /sessions
-          ...standardExportData.map((s: any, i: number) => ({
-            type: 'main',
-            sessionId: sessions[i]?.id,
-            execute: async () => {
-              await api.exportSession(s);
-              await api.updateSession({ exported: true }, { where: { id: sessions[i]?.id } });
-              return { success: true, id: sessions[i]?.id };
-            }
-          })),
-
-          // 2. Local export to /local (if hasLocalConfig)
-          ...(hasLocalConfig ? pollExportData.map((s: any, i: number) => ({
-            type: 'local',
-            sessionId: sessions[i]?.id,
-            execute: async () => {
-              if (sessions[i]?.local_export) return { success: true, skipped: true };
-
-              const { id, exported, local_export, ...exportable } = s;
-              const res = await api.makeLocalApiCall(
-                `/local?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`,
-                {
-                  method: 'POST',
-                  body: JSON.stringify(exportable),
-                }
-              );
-
-              if (res?.status === 200) {
-                await api.updateSession({ local_export: true }, { where: { id: sessions[i]?.id } });
-                return { success: true, id: sessions[i]?.id };
-              }
-              throw new Error(`Failed to local export session ${sessions[i]?.id}`);
-            }
-          })) : []),
-
-          // 3. Poll data export to /save-poll-data
-          ...pollExportData.map((s: any, i: number) => ({
-            type: 'poll',
-            sessionId: sessions[i]?.id,
-            execute: async () => {
-              if (sessions[i]?.exported) return { success: true, skipped: true };
-
-              const { id, exported, local_export, ...exportable } = s;
-              const res = await api.makeApiCall(
-                'nodeapi',
-                `/save-poll-data?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`,
-                {
-                  method: 'POST',
-                  body: JSON.stringify(exportable),
-                }
-              );
-              if (res?.status !== 200) {
-                throw new Error(`Failed to export poll data for session ${sessions[i]?.id}`);
-              }
-              return { success: true, id: sessions[i]?.id };
-            }
-          }))
-        ];
-
-        // Execute all API calls independently - failures don't affect other calls
-        const results = await Promise.allSettled(
-          apiCallGroups.map(group => group.execute())
+        const wasLocalDone = new Set(
+          sessions.filter((s: any) => !localRequired(s) || Boolean(s.local_export)).map((s: any) => s.id)
         );
 
-        // Collect failures for logging
-        const failures = results
-          .map((result, index) => ({ result, group: apiCallGroups[index] }))
-          .filter(({ result }) => result.status === 'rejected')
-          .map(({ result, group }) => ({
-            type: group.type,
-            sessionId: group.sessionId,
-            error: result.status === 'rejected' ? result.reason : null
-          }));
 
-        if (failures.length > 0) {
-          console.log('Export failures:', failures);
-          const mainFailures = failures.filter(f => f.type === 'main');
-          if (mainFailures.length > 0) {
-            await addToExportQueue(mainFailures.map(f => f.sessionId).filter(Boolean));
-          }
-          if (mainFailures.length > 0) {
-            throw new Error(`Failed to export ${mainFailures.length} session(s). Check network and try again.`);
-          }
-          // Local/poll failures are treated as warnings
+        const result = await api.doExportSessions(sessions);
+
+        const postRows: any[] = ((await api.getSessions()) as any[]) || [];
+        const postById: any = {};
+        postRows.forEach((s: any) => { if (s?.id !== undefined) postById[s.id] = s; });
+
+        const isRemoteDone = (s: any) => {
+          const row = postById[s.id] || s;
+          const pollSatisfied = !api.pollingRequired(s.data?.country) || Boolean(row.poll_exported);
+          return Boolean(row.exported) && pollSatisfied;
+        };
+        const isLocalDone = (s: any) => {
+
+          if (!localRequired(s)) return true;
+          return Boolean((postById[s.id] || s).local_export);
+        };
+
+        const remotePending = sessions.filter((s: any) => !isRemoteDone(s));
+        const localPending = sessions.filter((s: any) => !isLocalDone(s));
+
+        const sentRemote = sessions.filter((s: any) => isRemoteDone(s) && !wasRemoteDone.has(s.id));
+        const sentLocal = sessions.filter((s: any) => isLocalDone(s) && !wasLocalDone.has(s.id));
+        const alreadyDone = sessions.filter((s: any) => (
+          wasRemoteDone.has(s.id) && wasLocalDone.has(s.id)
+        ));
+
+        const clearedIds = sessions
+          .map((s: any) => s.id)
+          .filter((id: any) => Boolean(postById[id]?.exported));
+        if (clearedIds.length) await removeFromExportQueue(clearedIds);
+
+        const stillPendingMainIds = sessions
+          .map((s: any) => s.id)
+          .filter((id: any) => !postById[id]?.exported);
+        if (stillPendingMainIds.length) await addToExportQueue(stillPendingMainIds);
+
+        outcome = {
+          status: 'success',
+          localConfigured: result.localConfigured,
+          localOk: sentLocal.length,
+          remoteOk: sentRemote.length,
+          localPending: localPending.length,
+          remotePending: remotePending.length,
+          alreadyExported: alreadyDone.length,
+        };
+
+        if (remotePending.length || localPending.length) {
+          console.log('Export outcome:', {
+            sentRemote: sentRemote.length,
+            sentLocal: sentLocal.length,
+            alreadyExported: alreadyDone.length,
+            remotePending: remotePending.length,
+            localPending: localPending.length,
+          });
+
+          api.scheduleExportSessions();
         }
 
-        const mainSuccessIds = results
-          .map((result, index) => ({ result, group: apiCallGroups[index] }))
-          .filter(({ result, group }) => group.type === 'main' && result.status === 'fulfilled')
-          .map(({ group }) => group.sessionId)
-          .filter(Boolean);
+        if (!remotePending.length && !localPending.length) {
+          outcome.status = (!sentRemote.length && !sentLocal.length && alreadyDone.length)
+            ? 'already-exported'
+            : 'success';
+        } else if (sessions.some(localRequired) && !localPending.length && remotePending.length) {
+          outcome.status = 'local-only';
+        } else if (sentRemote.length || sentLocal.length) {
+          outcome.status = 'partial';
+        } else {
+          outcome.status = 'failed';
+        }
 
-        if (mainSuccessIds.length > 0) {
-          await removeFromExportQueue(mainSuccessIds);
+        if (outcome.status === 'failed') {
+          throw new Error(
+            `Could not export ${remotePending.length} session(s) — no server could be reached. `
+            + `The data is saved on this device and will be sent automatically once a server is available.`
+          );
         }
 
         });
 
-        resolve(null);
+        resolve(outcome);
       } catch (e) {
         console.log('Export error:', e);
         reject(e);
@@ -436,7 +462,7 @@ export function exportToApi(opts: any = {}) {
 export default function exportData(opts: any = {}) {
   const { format } = opts;
 
-  opts.sessions = (opts.sessions || []).filter((s: any) => s?.data?.completed_at || s?.data?.canceled_at);
+  opts.sessions = (opts.sessions || []).filter(api.isExportableSession);
 
   switch (format) {
     case 'jsonapi':

--- a/src/Home/Sessions/index.tsx
+++ b/src/Home/Sessions/index.tsx
@@ -23,11 +23,11 @@ const exportTypes = [
 
 const deleteTypes = [
 	{
-		label: 'All (except unexported complete sessions)',
+		label: 'All (except sessions still awaiting export)',
 		value: 'all',
 	},
 	{
-		label: 'Incomplete sessions',
+		label: 'Incomplete (unsubmitted) sessions',
 		value: 'incomplete',
 	},
 	{
@@ -82,6 +82,16 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 	const [localServerError, setLocalServerError] = React.useState('');
 	const [searchSource, setSearchSource] = React.useState<null | 'local' | 'localServer'>(null);
 	const [loadingSessionDetails, setLoadingSessionDetails] = React.useState(false);
+	const [location, setLocation] = React.useState<null | types.Location>(null);
+	const [hasLocalConfig, setHasLocalConfig] = React.useState(false);
+
+
+	const isDeliveredSession = React.useCallback(
+		(s: any) => api.isFullyDelivered(s, location, hasLocalConfig),
+		[location, hasLocalConfig]
+	);
+
+	const isDraftSession = React.useCallback((s: any) => !api.isTerminalSession(s), []);
 
 	const normalizeSessionForDisplay = async (session: any) => {
 		if (!session) return session;
@@ -323,7 +333,7 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 	};
 
 	const exportSessions = async (opts: any = {}) => {
-		const _dbSessions = dbSessions.filter((s: any) => s?.data?.completed_at);
+		const _dbSessions = dbSessions.filter(api.isExportableSession);
 		let sessions = _dbSessions;
 		switch (exportType) {
 			case 'date_range':
@@ -334,11 +344,43 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 		}
 		setExportingSessions(true);
 		try {
-			await exportData({ ...opts, format: exportFormat, sessions, scriptsFields, application, });
+			const result: any = await exportData({ ...opts, format: exportFormat, sessions, scriptsFields, application, });
 			if (exportFormat === 'jsonapi') await getSessions();
+
+			let title = '';
+			let message = 'Export success';
+			if (exportFormat === 'jsonapi') {
+				switch (result?.status) {
+					case 'already-exported':
+						title = 'Already exported';
+						message = result.alreadyExported === 1
+							? 'This session has already been exported. Nothing was sent again.'
+							: `All ${result.alreadyExported} selected sessions have already been exported.`;
+						break;
+					case 'local-only':
+						title = 'Saved to local server';
+						message = (result.localOk
+							? `${result.localOk} session(s) saved to the local server. `
+							: `These sessions are already saved on the local server. `)
+							+ `The cloud server can't be reached right now, Please try again later`;
+						break;
+					case 'partial':
+						title = 'Partially exported';
+						message = `Sent to the cloud: ${result.remoteOk}. `
+							+ (result.localConfigured ? `Saved locally: ${result.localOk}. ` : '')
+							+ (result.alreadyExported ? `Already exported previously: ${result.alreadyExported}. ` : '')
+							+ `Still queued: ${Math.max(result.remotePending, result.localPending)} session(s) — these retry automatically.`;
+						break;
+					default:
+						message = result?.localConfigured
+							? `Export success — sent to both the cloud and the local server.`
+							: 'Export success';
+				}
+			}
+
 			Alert.alert(
-				'',
-				'Export success',
+				title,
+				message,
 				[
 					{
 						text: 'Ok',
@@ -372,11 +414,34 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 		setShowExportFormats(false);
 	};
 
-	const deleteSessions = async (ids: any[] = []) => {
-		if (ids.length) {
+	const deleteSessions = async (ids: any[] = [], opts: { allowDrafts?: boolean } = {}) => {
+		if (!ids.length) return;
+
+		const allRows: any[] = ((await api.getSessions()) as any[]) || [];
+		const byId: any = {};
+		allRows.forEach((s: any) => { if (s?.id !== undefined) byId[s.id] = s; });
+
+		const requested = ids.map((id: any) => byId[id]).filter(Boolean);
+		const deletable = requested.filter((s: any) => (
+			isDeliveredSession(s) || (opts.allowDrafts && isDraftSession(s))
+		));
+		const blocked = requested.filter((s: any) => !deletable.includes(s));
+
+		if (!deletable.length) {
+			Alert.alert(
+				'Nothing deleted',
+				blocked.length === 1
+					? 'This session has not finished exporting yet, so it cannot be deleted. It will be sent automatically once a server is reachable.'
+					: `${blocked.length} session(s) have not finished exporting yet, so none were deleted. They will be sent automatically once a server is reachable.`,
+				[{ text: 'Ok' }]
+			);
+			return;
+		}
+
+		const proceed = async () => {
 			setDeletingSessions(true);
 			try {
-				await api.deleteSessions(ids);
+				await api.deleteSessions(deletable.map((s: any) => s.id));
 				await getSessions();
 			} catch (e: any) {
 				Alert.alert(
@@ -385,7 +450,7 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 				[
 					{
 						text: 'Try again',
-						onPress: () => deleteSessions(ids),
+						onPress: () => deleteSessions(ids, opts),
 					},
 					{
 						text: 'Cancel',
@@ -393,10 +458,25 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 					}
 				]
 				);
-				
+
 			}
 			setDeletingSessions(false);
+		};
+
+		if (blocked.length) {
+			Alert.alert(
+				'Some sessions kept',
+				`${blocked.length} session(s) have not finished exporting and will be kept. `
+				+ `Delete the remaining ${deletable.length} session(s)?`,
+				[
+					{ text: 'Cancel', style: 'cancel' },
+					{ text: 'Delete', onPress: () => { proceed(); } },
+				]
+			);
+			return;
 		}
+
+		await proceed();
 	};
 
 	React.useEffect(() => {
@@ -490,6 +570,8 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 			setLoadingSessions((loader === undefined) || loader);
 			try {
 				const location = await api.getLocation();
+				setLocation(location);
+				setHasLocalConfig(await api.hasLocalServerConfig());
 				const sessions: any = await api.getSessions();
 				const dbSessions = (sessions || []).filter((s: any) => {
 					return (
@@ -734,24 +816,26 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 									}}
 								>
 									<Card>
-										{!!item.exported && (
+										{(!!item.exported || !!item.local_export) && (
 											<>
 												<Box flexDirection="row">
-													<Box 
-														backgroundColor="success"
-														paddingVertical="s"
-														paddingHorizontal="m"
-														borderRadius="xl"
-													>
-														<Text
-															textAlign="center"
-															variant="caption"
-															color="successContrastText"
-														>Exported Online</Text>
-													</Box>
-													
-													{!!item.local_export && (	
-														<Box 
+													{!!item.exported && (
+														<Box
+															backgroundColor="success"
+															paddingVertical="s"
+															paddingHorizontal="m"
+															borderRadius="xl"
+														>
+															<Text
+																textAlign="center"
+																variant="caption"
+																color="successContrastText"
+															>Exported Online</Text>
+														</Box>
+													)}
+
+													{!!item.local_export && (
+														<Box
 															backgroundColor="highlight"
 															paddingVertical="s"
 															paddingHorizontal="xl"
@@ -885,12 +969,18 @@ export function Sessions({ navigation }: types.StackNavigationProps<types.HomeRo
 							setOpenDeleteModal(false);
 							switch (deleteType) {
 								case 'all':
-									const unexportedCompleteSessions = dbSessions.filter((s: any) => !s.exported && s?.data?.completed_at);
-									const deletable = dbSessions.filter((s: any) => !unexportedCompleteSessions.find((s2: any) => s2.id === s.id))
-									deleteSessions(deletable.map((s: any) => s.id));
+									deleteSessions(
+										dbSessions
+											.filter((s: any) => isDeliveredSession(s) || isDraftSession(s))
+											.map((s: any) => s.id),
+										{ allowDrafts: true }
+									);
 									break;
 								case 'incomplete':
-									deleteSessions(dbSessions.filter((s: any) => !s?.data?.completed_at).map((s: any) => s.id));
+									deleteSessions(
+										dbSessions.filter(isDraftSession).map((s: any) => s.id),
+										{ allowDrafts: true }
+									);
 									break;
 								case 'date_range':
 									deleteSessions(getFilteredSessions(dbSessions, { minDate, maxDate }).map((s: any) => s.id));

--- a/src/components/LocationForm.tsx
+++ b/src/components/LocationForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ActivityIndicator } from "react-native";
-import { countries, SDK_VERSION } from '@/src/constants';
+import { countries,} from '@/src/constants';
 
 import { useTheme, Text  } from "./Theme";
 import { Br } from './Br';
@@ -43,6 +43,7 @@ export function LocationForm({ onSetLocation, buttonLabel }: LocationFormProps) 
 						`insert or replace into location (${Object.keys(location).join(',')}) values (${Object.keys(location).map(() => '?').join(',')});`,
 						Object.values(location),
 					);
+					api.invalidateLocationCache();
 					onSetLocation();
 					setSubmitting(false);
 				} else {

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -4,12 +4,36 @@ import queryString from 'query-string';
 import { APP_CONFIG } from '@/src/constants';
 import * as types from '../types';
 import { getLocation } from './queries';
+import {
+    acquireAttempt,
+    recordSuccess,
+    recordFailure,
+    backendKey,
+    NetworkUnavailableError,
+} from './circuitBreaker';
 
+const PROBE_TIMEOUT_MS = 15_000;
+const REMOTE_TIMEOUT_MS = 60_000;
+const LOCAL_TIMEOUT_MS = 30_000;
+
+export const SYNC_DOWNLOAD_TIMEOUT_MS = 300_000;
+export const REMOTE_PROBE_TIMEOUT_MS = PROBE_TIMEOUT_MS;
 
 const _otherOptions = {
     useHost: false,
 	country: '',
+	hospital: '',
+	timeout: REMOTE_TIMEOUT_MS,
 };
+
+export function resolveLocalServer(country: string | null | undefined, hospital: string | null | undefined) {
+    if (!country) return null;
+    const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)?.['local'];
+    if (!Array.isArray(config) || !config.length) return null;
+    const trimmedHospital = hospital?.trim();
+    if (!trimmedHospital) return null;
+    return config.find(c => c.hospital === trimmedHospital) || null;
+}
 
 export async function makeApiCall(
     source: 'webeditor' | 'nodeapi', 
@@ -17,7 +41,7 @@ export async function makeApiCall(
     options: RequestInit = {},
     otherOptions: Partial<(typeof _otherOptions)> = _otherOptions,
 ) {
-    const { useHost } = { ..._otherOptions, ...otherOptions, };
+    const { useHost, timeout: timeoutMs } = { ..._otherOptions, ...otherOptions, };
     let url = '';
     try {
         const location = await getLocation();
@@ -34,9 +58,20 @@ export async function makeApiCall(
         endpoint = endpoint[0] === '/' ? endpoint.substring(1) : endpoint;
         url = [api_endpoint, endpoint].join('/').replace(/\?+$/, '');
 
+        const circuitKey = backendKey(country, source);
+        if (!(await acquireAttempt(circuitKey))) throw new NetworkUnavailableError(source);
+
         console.log('[API]: ', url);
+
+        let settled = false;
+        const settle = (ok: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (ok) recordSuccess(circuitKey); else recordFailure(circuitKey);
+        };
+
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 300000);
+        const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
         try {
             const res = await fetch(url, {
@@ -48,14 +83,17 @@ export async function makeApiCall(
                     'x-api-key': config.api_key,
                 },
             });
+            settle(true);
             return res;
         } catch(err:any) {
+            settle(false);
             if (err.name === 'AbortError') {
-                throw new Error('Network request timed out after 5 minutes. Check your connection and try again.');
+                throw new Error('Network request timed out. Check your connection and try again.');
             }
             throw err;
         } finally {
             clearTimeout(timeout);
+            settle(false);
         }
     } catch(e) {
         // if (process.env.APP_ENV !== 'PROD') console.error(`[ERROR]: ${url}`, e);
@@ -71,26 +109,37 @@ export async function makeLocalApiCall(
     try {
         const location = await getLocation();
         const country = otherOptions.country || location?.country;
+        const hospital = otherOptions.hospital || location?.hospital;
 
         if (!country) throw new Error('Location not set');
 
-        const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)['local'];
-        if(config && Array.isArray(config)){
+        const target = resolveLocalServer(country, hospital);
+        if(target){
 
-        let api_endpoint =  config?.[0].host;
-        api_endpoint[api_endpoint.length - 1] === '/' ? 
+        let api_endpoint =  target.host;
+        api_endpoint[api_endpoint.length - 1] === '/' ?
             api_endpoint.substring(0, api_endpoint.length - 1) : api_endpoint;
 
         endpoint = endpoint[0] === '/' ? endpoint.substring(1) : endpoint;
         url = [api_endpoint, endpoint].join('/');
 
+        const sec = target.secret;
+        const body = encryptInReactNative(options.body, sec);
+
+        const circuitKey = backendKey(country, 'local', hospital);
+        if (!(await acquireAttempt(circuitKey))) throw new NetworkUnavailableError('local');
+
         console.log('[API]: ', url);
-    
-       const sec = config?.[0].secret
-        const body =encryptInReactNative(options.body, sec);
+
+        let settled = false;
+        const settle = (ok: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (ok) recordSuccess(circuitKey); else recordFailure(circuitKey);
+        };
 
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 30000);
+        const timeout = setTimeout(() => controller.abort(), LOCAL_TIMEOUT_MS);
 
         let res;
         try {
@@ -101,16 +150,19 @@ export async function makeLocalApiCall(
                 headers: {
                     'Content-Type': 'application/json',
                     ...options.headers,
-                    'x-api-key': config?.[0].api_key,
+                    'x-api-key': target.api_key,
                 }
             });
+            settle(true);
         } catch (err: any) {
+            settle(false);
             if (err.name === 'AbortError') {
                 throw new Error('Local Server Connection Taking Longer Than The Expected 30 Seconds. Check With The Administrator if it is up!!');
             }
             throw err;
         } finally {
             clearTimeout(timeout);
+            settle(false);
         }
 
         if (res.status !== 200) {
@@ -137,57 +189,68 @@ export async function makeLocalGetApiCall(
 
         if (!country) throw new Error('Location not set');
 
-        const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)['local'];
         const queryString = endpoint.split('?')[1];
         const params = new URLSearchParams(queryString);
         const hospitalId = params.get("hospital");
 
-        if(!config || !Array.isArray(config) || config.length<=0){
-            return null
-        }
-        if(config.length>0 && config[0]['hospital']!=hospitalId){
+        const target = resolveLocalServer(country, hospitalId);
+        if(!target){
             return null
         }
         else{
-        let api_endpoint =  config?.[0].host;
-        api_endpoint[api_endpoint.length - 1] === '/' ? 
+        let api_endpoint =  target.host;
+        api_endpoint[api_endpoint.length - 1] === '/' ?
             api_endpoint.substring(0, api_endpoint.length - 1) : api_endpoint;
 
         endpoint = endpoint[0] === '/' ? endpoint.substring(1) : endpoint;
         url = [api_endpoint, endpoint].join('/');
 
+        const sec = target.secret;
+
+        const circuitKey = backendKey(country, 'local', hospitalId);
+        if (!(await acquireAttempt(circuitKey))) throw new NetworkUnavailableError('local');
+
         console.log('[API]: ', url);
-    
-       const sec = config?.[0].secret
+
+        let settled = false;
+        const settle = (ok: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (ok) recordSuccess(circuitKey); else recordFailure(circuitKey);
+        };
 
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 30000);
+        const timeout = setTimeout(() => controller.abort(), LOCAL_TIMEOUT_MS);
 
-          try {
-
-        const res = await fetch(url, {
-            method:'GET',
-            signal: controller.signal,
-            headers: {
-                'Content-Type': 'application/json',
-                ...options.headers,
-                'x-api-key': config?.[0].api_key,
+        let res;
+        try {
+            res = await fetch(url, {
+                method:'GET',
+                signal: controller.signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...options.headers,
+                    'x-api-key': target.api_key,
+                }
+            });
+            settle(true);
+        } catch (err: any) {
+            settle(false);
+            if (err.name === 'AbortError') {
+                throw new Error('Local Server Connection Taking Longer Than The Expected 30 Seconds. Check With The Administrator if it is up!!');
             }
-        });
-        
+            throw err;
+        } finally {
+            clearTimeout(timeout);
+            settle(false);
+        }
+
         if (res.status !== 200) {
             console.log(res);
         }
-       
-        const sessions = decryptInReactNative(await res?.json(),sec)
-        clearTimeout(timeout);
+
+        const sessions = decryptInReactNative(await res?.json(), sec);
         return sessions;
-    }catch (err:any) {
-        if (err.name === 'AbortError') {
-            throw new Error('Local Server Connection Taking Longer Than The Expected 30 Seconds. Check With The Administrator if it is up!!');
-        }
-        throw err;
-       }
     }
    
     } catch(e) {
@@ -198,12 +261,8 @@ export async function makeLocalGetApiCall(
 export async function hasLocalServerConfig() {
     try {
         const location = await getLocation();
-        const country = location?.country;
-        if (!country) return false;
-        const config = (APP_CONFIG[country] as types.COUNTRY_CONFIG)['local'];
-        const hospital = location?.hospital;
-        const localConfig = Array.isArray(config) ? config.filter(c => c.hospital === hospital?.trim()) : [];
-        return Boolean(localConfig?.[0]?.hospital?.length);
+        if (!location?.country) return false;
+        return Boolean(resolveLocalServer(location.country, location.hospital));
     } catch {
         return false;
     }

--- a/src/data/circuitBreaker.ts
+++ b/src/data/circuitBreaker.ts
@@ -1,0 +1,253 @@
+export type Backend = 'nodeapi' | 'webeditor' | 'local';
+
+export type BackendKey = string;
+
+export function backendKey(country: string | null | undefined, backend: Backend, hospital?: string | null): BackendKey {
+    return hospital ? `${country || 'unknown'}:${backend}:${hospital}` : `${country || 'unknown'}:${backend}`;
+}
+
+// Consecutive network failures before a backend is considered down. Kept low so
+// a genuine outage is detected quickly, but above 1 so a single transient blip
+// doesn't trip it.
+const FAILURE_THRESHOLD = 2;
+
+// Base cooldown for the first time a circuit opens; doubles (capped) each time
+// the half-open probe itself fails, so a persistent outage backs off instead
+// of re-probing every 30s forever.
+const BASE_COOLDOWN_MS = 30_000;
+const MAX_COOLDOWN_MS = 5 * 60_000;
+const JITTER_RATIO = 0.2; // +/-20%, so many devices don't all re-probe in lockstep
+
+type CircuitPhase = 'closed' | 'open' | 'half-open';
+
+interface CircuitState {
+    phase: CircuitPhase;
+    failures: number;
+    openUntil: number; // epoch ms; meaningful only while phase === 'open'
+    probeInFlight: boolean; // meaningful only while phase === 'half-open'
+}
+
+const CLOSED_STATE: CircuitState = { phase: 'closed', failures: 0, openUntil: 0, probeInFlight: false };
+
+const circuits = new Map<BackendKey, CircuitState>();
+
+function get(key: BackendKey): CircuitState {
+    return circuits.get(key) || CLOSED_STATE;
+}
+
+function backoffCooldown(failures: number): number {
+    const exponent = Math.max(0, failures - FAILURE_THRESHOLD);
+    const raw = Math.min(BASE_COOLDOWN_MS * (2 ** exponent), MAX_COOLDOWN_MS);
+    const jitter = raw * JITTER_RATIO * (Math.random() * 2 - 1);
+    return Math.max(BASE_COOLDOWN_MS, Math.round(raw + jitter));
+}
+
+function openCircuit(key: BackendKey, failures: number): void {
+    const openUntil = Date.now() + backoffCooldown(failures);
+    circuits.set(key, { phase: 'open', failures, openUntil, probeInFlight: false });
+    armCooldownTimer(key, openUntil);
+}
+
+/**
+ * True when a caller should not even bother trying `key` right now: the
+ * circuit is fully open, or it's half-open and another caller already claimed
+ * the one probe attempt. A pure status read — safe to call as often as
+ * needed (pool "should I keep pulling items" checks, UI status, etc.) since it
+ * never itself changes state. It does NOT grant permission to actually make a
+ * request during half-open; see `tryAcquireAttempt` for that.
+ */
+export function isBackendDown(key: BackendKey): boolean {
+    const c = get(key);
+    if (c.phase === 'open') return true;
+    if (c.phase === 'half-open') return c.probeInFlight;
+    return false;
+}
+
+/**
+ * Claims permission to actually fire a request against `key` right now.
+ * Unlike `isBackendDown`, this mutates state and must be called exactly once
+ * per real attempt, immediately before making it. While closed, always
+ * grants it. While open, always refuses. While half-open, grants it to
+ * exactly one caller (first past the post — safe under concurrency because JS
+ * runs this synchronous check-and-set to completion before any other caller's
+ * code can run) and refuses everyone else until that probe's outcome is
+ * recorded via `recordSuccess`/`recordFailure`.
+ *
+ * Most callers want `acquireAttempt` instead — this synchronous version is
+ * exposed for callers that genuinely can't await (there are none today, but
+ * it's the primitive `acquireAttempt` is built on).
+ */
+export function tryAcquireAttempt(key: BackendKey): boolean {
+    const c = get(key);
+    if (c.phase === 'open') return false;
+    if (c.phase === 'half-open') {
+        if (c.probeInFlight) return false;
+        circuits.set(key, { ...c, probeInFlight: true });
+        startProbeOutcome(key);
+        return true;
+    }
+    return true;
+}
+
+const probeOutcomes = new Map<BackendKey, {
+    promise: Promise<boolean>;
+    resolve: (ok: boolean) => void;
+    watchdog: ReturnType<typeof setTimeout>;
+}>();
+
+// Absolute ceiling on how long a half-open probe may hold its permit. Callers
+// are expected to settle via recordSuccess/recordFailure, but a bug on any
+// single path between acquiring the permit and settling it would otherwise
+// wedge that backend permanently — every later caller would wait on a promise
+// that never resolves. This is the independent safety net for that: longer
+// than any request timeout, so it only ever fires when something genuinely
+// went wrong rather than pre-empting a slow-but-live request.
+const PROBE_WATCHDOG_MS = 60_000;
+
+function startProbeOutcome(key: BackendKey): void {
+    let resolveFn: (ok: boolean) => void = () => {};
+    const promise = new Promise<boolean>(resolve => { resolveFn = resolve; });
+    const watchdog = setTimeout(() => {
+        // Treat a stranded probe as a failure: reopen so the normal cooldown
+        // path takes over, and release anyone waiting behind it.
+        if (circuits.get(key)?.phase === 'half-open') recordFailure(key);
+        else settleProbeOutcome(key, false);
+    }, PROBE_WATCHDOG_MS);
+    probeOutcomes.set(key, { promise, resolve: resolveFn, watchdog });
+}
+
+function settleProbeOutcome(key: BackendKey, ok: boolean): void {
+    const entry = probeOutcomes.get(key);
+    if (entry) {
+        clearTimeout(entry.watchdog);
+        entry.resolve(ok);
+        probeOutcomes.delete(key);
+    }
+}
+
+/**
+ * The async, "wait your turn" version of `tryAcquireAttempt` — what callers
+ * should actually use. If the slot is free (closed, or half-open with no
+ * probe running), grants it immediately, same as the sync version. If a
+ * half-open probe is already in flight, waits for its outcome instead of
+ * refusing outright: succeeds if the probe succeeded (the circuit is closed
+ * now), refuses if it failed.
+ */
+export async function acquireAttempt(key: BackendKey): Promise<boolean> {
+    if (tryAcquireAttempt(key)) return true;
+    const entry = probeOutcomes.get(key);
+    if (!entry) return tryAcquireAttempt(key); // open, or the race already settled
+    const ok = await entry.promise;
+    return ok ? tryAcquireAttempt(key) : false;
+}
+
+/** Record a reachable backend (any HTTP response). Closes the circuit. */
+export function recordSuccess(key: BackendKey): void {
+    clearCooldownTimer(key);
+    const wasHalfOpen = circuits.get(key)?.phase === 'half-open';
+    if (circuits.has(key)) circuits.set(key, { ...CLOSED_STATE });
+    if (wasHalfOpen) settleProbeOutcome(key, true);
+}
+
+/**
+ * Record a network-level failure. Opens the circuit once the threshold is
+ * hit; a failed half-open probe reopens it with a longer backoff cooldown.
+ * Failures arriving while already open are ignored — see the open-phase
+ * branch below.
+ */
+export function recordFailure(key: BackendKey): void {
+    const c = get(key);
+
+    if (c.phase === 'open') {
+
+        return;
+    }
+
+    if (c.phase === 'half-open') {
+        openCircuit(key, c.failures + 1);
+        settleProbeOutcome(key, false);
+        return;
+    }
+
+    const failures = c.failures + 1;
+    if (failures >= FAILURE_THRESHOLD) {
+        openCircuit(key, failures);
+    } else {
+        circuits.set(key, { ...c, phase: 'closed', failures });
+    }
+}
+
+type CooldownListener = () => void;
+const cooldownListeners = new Set<CooldownListener>();
+const cooldownTimers = new Map<BackendKey, ReturnType<typeof setTimeout>>();
+
+function clearCooldownTimer(key: BackendKey): void {
+    const existing = cooldownTimers.get(key);
+    if (existing) {
+        clearTimeout(existing);
+        cooldownTimers.delete(key);
+    }
+}
+
+function armCooldownTimer(key: BackendKey, openUntil: number): void {
+    clearCooldownTimer(key);
+    const delay = Math.max(0, openUntil - Date.now());
+    cooldownTimers.set(key, setTimeout(() => {
+        cooldownTimers.delete(key);
+        const c = circuits.get(key);
+        if (c && c.phase === 'open') {
+            circuits.set(key, { ...c, phase: 'half-open', probeInFlight: false });
+        }
+        notifyCooldownExpired();
+    }, delay));
+}
+
+function notifyCooldownExpired(): void {
+    cooldownListeners.forEach(listener => {
+        try { listener(); } catch { /* one listener's failure shouldn't stop the others */ }
+    });
+}
+
+/**
+ * Registers a callback to run whenever any circuit's cooldown naturally
+ * expires (transitions open → half-open). Returns an unsubscribe function.
+ * Not tied to any specific key — callers that care which backend recovered
+ * should re-check `isBackendDown` themselves; this is purely a "something may
+ * be worth retrying now" nudge. Note the transition only opens the door to a
+ * single probe attempt, not a free-for-all — see `tryAcquireAttempt`.
+ */
+export function onCircuitCooldownExpired(listener: CooldownListener): () => void {
+    cooldownListeners.add(listener);
+    return () => cooldownListeners.delete(listener);
+}
+
+/** Force a backend back to healthy (e.g. after connectivity is restored). */
+export function resetCircuit(key: BackendKey): void {
+    circuits.delete(key);
+    clearCooldownTimer(key);
+    settleProbeOutcome(key, true);
+}
+
+/**
+ * Force every circuit (every country/backend combination) back to healthy.
+ * Used when connectivity is restored and the country of any given open circuit
+ * isn't known at the call site — give everything a fresh chance rather than
+ * trying to enumerate keys.
+ */
+export function resetAllCircuits(): void {
+    circuits.clear();
+    cooldownTimers.forEach(timer => clearTimeout(timer));
+    cooldownTimers.clear();
+    Array.from(probeOutcomes.keys()).forEach(key => settleProbeOutcome(key, true));
+}
+
+/** Thrown when a call is short-circuited because its backend is known to be down. */
+export class NetworkUnavailableError extends Error {
+    readonly backend: BackendKey;
+    readonly isOffline = true;
+    constructor(backend: BackendKey) {
+        super(`${backend} is currently unreachable`);
+        this.name = 'NetworkUnavailableError';
+        this.backend = backend;
+    }
+}

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -3,7 +3,7 @@ import * as SQLite from 'expo-sqlite';
 
 export const db = SQLite.openDatabaseSync('db.db');
 
-export const dbTransaction = (q: string, data: any = null, cb?: (e: any, rslts?: any) => void) => new Promise<any[]>((resolve, reject) => {
+export const dbTransaction = (q: string, data: any = null, cb?: (e: any, rslts?: any) => void, handle: any = db) => new Promise<any[]>((resolve, reject) => {
     const done = (error?: null | Error, data?: any[]) => {
         if (error) {
             reject(error);
@@ -12,8 +12,8 @@ export const dbTransaction = (q: string, data: any = null, cb?: (e: any, rslts?:
         }
         cb?.(error, data);
     };
-    db.getAllAsync<any>(q, data)
-        .then(res => done(null, res))
+    handle.getAllAsync(q, data)
+        .then((res: any) => done(null, res))
         .catch(done);
 });
 
@@ -83,6 +83,8 @@ export async function createTablesIfNotExist() {
         'data text',
         'completed boolean',
         'exported boolean',
+        'local_export boolean default 0',
+        'poll_exported boolean default 0',
         'createdAt datetime',
         'updatedAt datetime',
     ].join(',');
@@ -185,11 +187,22 @@ export async function createTablesIfNotExist() {
           await dbTransaction(`ALTER TABLE sessions ADD COLUMN local_export BOOLEAN DEFAULT 0;`);
 
      }
+
+     const pollExportedExists = sessionsTableInfo.some((col: any) => col.name === 'poll_exported');
+     if(!pollExportedExists){
+          await dbTransaction(`ALTER TABLE sessions ADD COLUMN poll_exported BOOLEAN DEFAULT 0;`);
+     }
   }
 }
 
-export const resetTables = async () => {
+
+export async function ensureSchema() {
     await createTablesIfNotExist();
+    await addNewColumns();
+}
+
+export const resetTables = async () => {
+    await ensureSchema();
     return await Promise.all([
         // 'delete * from application where 1;',
         'delete * from scripts where 1;',
@@ -221,6 +234,7 @@ export const resetApp = async () => {
         dbTransaction(`drop table if exists exports;`),
         dbTransaction(`drop table if exists exceptions;`),
         dbTransaction(`drop table if exists aliases;`),
-    ]); 
-    await createTablesIfNotExist();
+        dbTransaction(`drop table if exists nt_aliases;`),
+    ]);
+    await ensureSchema();
 };

--- a/src/data/exportOnReconnect.ts
+++ b/src/data/exportOnReconnect.ts
@@ -2,6 +2,7 @@ import { InteractionManager } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 
 import { exportSessions } from './exportSessions';
+import { resetAllCircuits } from './circuitBreaker';
 
 let unsubscribe: (() => void) | null = null;
 let wasOnline: boolean | null = null;
@@ -36,7 +37,10 @@ export function registerExportOnReconnect() {
         const cameBackOnline = wasOnline === false && online;
         wasOnline = online;
 
-        if (cameBackOnline) queueSilentFlush();
+        if (cameBackOnline) {
+            resetAllCircuits();
+            queueSilentFlush();
+        }
     });
 
     unsubscribe = () => {

--- a/src/data/exportSessions.ts
+++ b/src/data/exportSessions.ts
@@ -1,115 +1,316 @@
+import { InteractionManager } from 'react-native';
+
+import { APP_CONFIG } from '@/src/constants';
+import * as types from '../types';
 import { dbTransaction } from './db';
 import { convertSessionsToExportable } from './convertSessionsToExportable';
 import { makeApiCall, makeLocalApiCall, hasLocalServerConfig } from './api';
 import { updateSession } from './updateSession';
 import { withExportLock } from './exportLock';
+import { getLocation } from './queries';
+import { isBackendDown, backendKey, onCircuitCooldownExpired } from './circuitBreaker';
 
-const doExportSessions = (sessions?: any[]) => new Promise((resolve, reject) => {
+
+export function pollingRequired(country: string): boolean {
+    return (APP_CONFIG[country] as types.COUNTRY_CONFIG | undefined)?.savePollingData !== false;
+}
+
+export function isTerminalSession(session: any): boolean {
+    return Boolean(session?.data?.completed_at || session?.data?.canceled_at);
+}
+
+/**
+ * The hard export boundary: only successfully completed sessions may leave
+ * the device. Canceled and interrupted sessions are deliberately excluded,
+ * regardless of which caller supplied them or which delivery flag is pending.
+ */
+export function isExportableSession(session: any): boolean {
+    return Boolean(session?.data?.completed_at && !session?.data?.canceled_at);
+}
+
+export function localRequiredForSession(
+    session: any,
+    location: { country?: string | null; hospital?: string | null } | null | undefined,
+    hasLocalConfig: boolean,
+): boolean {
+    if (!hasLocalConfig) return false;
+    if (!location?.country || !location?.hospital) return false;
+    return session?.data?.country === location.country
+        && session?.data?.hospital_id === location.hospital;
+}
+
+export function isFullyDelivered(
+    session: any,
+    location: { country?: string | null; hospital?: string | null } | null | undefined,
+    hasLocalConfig: boolean,
+): boolean {
+    if (!session) return false;
+    // Canceled sessions have no delivery obligation and can be deleted, but
+    // they must never be sent or have export flags advanced.
+    if (session?.data?.canceled_at && !isExportableSession(session)) return true;
+    if (!isExportableSession(session)) return false;
+
+    if (!session.exported) return false;
+    if (pollingRequired(session?.data?.country) && !session.poll_exported) return false;
+    if (localRequiredForSession(session, location, hasLocalConfig) && !session.local_export) return false;
+    return true;
+}
+
+
+const afterInteractions = () => new Promise<void>(resolve => {
+    InteractionManager.runAfterInteractions(() => resolve());
+});
+
+const EXPORT_CONCURRENCY = 5;
+
+async function runPooled<T>(
+    items: T[],
+    concurrency: number,
+    stop: () => boolean,
+    worker: (item: T, index: number) => Promise<void>,
+): Promise<T[]> {
+    let cursor = 0;
+    const lanes = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+        while (cursor < items.length) {
+            if (stop()) return;
+            const i = cursor++;
+            await worker(items[i], i);
+        }
+    });
+    await Promise.allSettled(lanes);
+    return items.slice(cursor);
+}
+
+export interface ExportBatchResult {
+    failedMain: any[];
+    failedPoll: any[];
+    failedLocal: any[];
+    okMain: any[];
+    okPoll: any[];
+    okLocal: any[];
+    localConfigured: boolean;
+    remoteSkipped: boolean;
+    localSkipped: boolean;
+}
+
+const emptyResult = (): ExportBatchResult => ({
+    failedMain: [], failedPoll: [], failedLocal: [],
+    okMain: [], okPoll: [], okLocal: [],
+    localConfigured: false,
+    remoteSkipped: false,
+    localSkipped: false,
+});
+
+
+function groupByCountry(sessions: any[], fallbackCountry: string | undefined | null): Map<string, any[]> {
+    const groups = new Map<string, any[]>();
+    for (const s of sessions) {
+        const key = s.data?.country || fallbackCountry || 'unknown';
+        const list = groups.get(key);
+        if (list) list.push(s); else groups.set(key, [s]);
+    }
+    return groups;
+}
+
+interface CohortContext {
+    cohortCountry: string;
+    cohortSessions: any[];
+    hasLocalConfig: boolean;
+    location: { country?: string | null; hospital?: string | null } | null | undefined;
+    result: ExportBatchResult;
+}
+
+function markCohortPending(ctx: CohortContext, reason: string, e?: unknown): void {
+    const { cohortCountry, cohortSessions, hasLocalConfig, location, result } = ctx;
+    console.log('exportSessions cohort', reason, cohortCountry, e);
+    cohortSessions.forEach(s => {
+        if (!s.exported) result.failedMain.push(s.id);
+        if (pollingRequired(cohortCountry) && !s.poll_exported) result.failedPoll.push(s.id);
+        if (localRequiredForSession(s, location, hasLocalConfig) && !s.local_export) result.failedLocal.push(s.id);
+    });
+}
+
+async function processCountryCohort(ctx: CohortContext): Promise<void> {
+    const { cohortCountry, cohortSessions, hasLocalConfig, location, result } = ctx;
+    const currentHospital = location?.hospital;
+
+    const pollRequired = pollingRequired(cohortCountry);
+    if (!pollRequired) {
+        const neverNeedsPoll = cohortSessions.filter(s => !s.poll_exported);
+        // A db failure here must not be swallowed — see markCohortPending.
+        await Promise.all(neverNeedsPoll.map(s => updateSession({ poll_exported: true }, { where: { id: s.id } })));
+    }
+
+    const localOwed = cohortSessions.filter(s => localRequiredForSession(s, location, hasLocalConfig));
+    const allowLocal = localOwed.length > 0;
+
+    const remoteUp = !isBackendDown(backendKey(cohortCountry, 'nodeapi'));
+    const localUp = allowLocal && !isBackendDown(backendKey(cohortCountry, 'local', currentHospital));
+
+    if (!remoteUp) result.remoteSkipped = true;
+    if (allowLocal && !localUp) result.localSkipped = true;
+
+    if (!remoteUp && !localUp) return;
+
+    const remoteExportData: any[] = remoteUp ? cohortSessions.filter(s => !s.exported) : [];
+    const remotePollExportData: any[] = (remoteUp && pollRequired) ? cohortSessions.filter(s => !s.poll_exported) : [];
+
+    const localExportData: any[] = localUp ? localOwed.filter(s => !s.local_export) : [];
+
+    if (!remoteExportData.length && !remotePollExportData.length && !localExportData.length) return;
+
+    let standardData: any[];
+    let confidentialData: any[];
+    try {
+        standardData = remoteExportData.length ? await convertSessionsToExportable(remoteExportData) as any[] : [];
+        const confidentialSource = Array.from(
+            new Map([...remotePollExportData, ...localExportData].map(s => [s.id, s])).values()
+        );
+        confidentialData = confidentialSource.length
+            ? await convertSessionsToExportable(confidentialSource, { showConfidential: true }) as any[]
+            : [];
+    } catch (e) {
+        // Conversion failed before a single network call was attempted — every
+        // session pending for any destination here is still pending.
+        console.log('exportSessions cohort conversion', cohortCountry, e);
+        remoteExportData.forEach(s => result.failedMain.push(s.id));
+        remotePollExportData.forEach(s => result.failedPoll.push(s.id));
+        localExportData.forEach(s => result.failedLocal.push(s.id));
+        return;
+    }
+
+    const promises: Promise<any>[] = [];
+
+    // --- Remote export: /sessions + /save-poll-data --------------------
+    if (remoteUp) {
+        const remoteDown = () => isBackendDown(backendKey(cohortCountry, 'nodeapi'));
+
+        promises.push(runPooled(standardData, EXPORT_CONCURRENCY, remoteDown, async (s: any, i: number) => {
+            try {
+                const { id, exported, local_export, poll_exported, ...exportable } = s;
+                const res = await makeApiCall('nodeapi', `/sessions?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
+                    method: 'POST',
+                    body: JSON.stringify(exportable),
+                }, { country: cohortCountry });
+                if (res?.status === 200) {
+                    await updateSession({ exported: true }, { where: { id, }, });
+                    result.okMain.push(id);
+                } else {
+                    result.failedMain.push(id);
+                }
+            } catch (e) {
+                result.failedMain.push(remoteExportData[i].id);
+                console.log(e);
+            }
+        }).then(deferred => { deferred.forEach((s: any) => result.failedMain.push(s.id)); }));
+
+        const remotePollConfidentialData = confidentialData.filter((s: any) => !s.poll_exported);
+        promises.push(runPooled(remotePollConfidentialData, EXPORT_CONCURRENCY, remoteDown, async (s: any) => {
+            const { id, exported, local_export, poll_exported, ...exportable } = s;
+            try {
+                const res = await makeApiCall('nodeapi', `/save-poll-data?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
+                    method: 'POST',
+                    body: JSON.stringify(exportable),
+                }, { country: cohortCountry });
+                if (res?.status === 200) {
+                    await updateSession({ poll_exported: true }, { where: { id, }, });
+                    result.okPoll.push(id);
+                } else {
+                    result.failedPoll.push(id);
+                }
+            } catch (e) {
+                result.failedPoll.push(id);
+                console.log(e);
+            }
+        }).then(deferred => { deferred.forEach((s: any) => result.failedPoll.push(s.id)); }));
+    }
+
+    // --- Local export: /local ------------------------------------------
+    if (localUp) {
+        const localDown = () => isBackendDown(backendKey(cohortCountry, 'local', currentHospital));
+
+        const localEligibleIds = new Set(localExportData.map((s: any) => s.id));
+        const localConfidentialData = confidentialData.filter((s: any) => !s.local_export && localEligibleIds.has(s.id));
+        promises.push(runPooled(localConfidentialData, EXPORT_CONCURRENCY, localDown, async (s: any) => {
+            const { id, exported, local_export, poll_exported, ...exportable } = s;
+            try {
+                const res = await makeLocalApiCall(`/local?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
+                    method: 'POST',
+                    body: JSON.stringify(exportable),
+                }, { country: cohortCountry, hospital: currentHospital ?? undefined });
+                if (res?.status === 200) {
+                    await updateSession({ local_export: true }, { where: { id, }, });
+                    result.okLocal.push(id);
+                } else {
+                    result.failedLocal.push(id);
+                }
+            } catch (e) {
+                result.failedLocal.push(id);
+                console.log(e);
+            }
+        }).then(deferred => { deferred.forEach((s: any) => result.failedLocal.push(s.id)); }));
+    }
+
+    await Promise.allSettled(promises);
+}
+
+export const doExportSessions = (sessions?: any[]): Promise<ExportBatchResult> => new Promise((resolve, reject) => {
     (async () => {
         try {
             const hasLocalConfig = await hasLocalServerConfig();
+            const location = await getLocation();
+            const currentCountry = location?.country;
+            const currentHospital = location?.hospital;
 
-			let dbSessions = [];
-
-            // only local-server sites track local_export; querying it at other
-            // sites would rescan every exported session forever
+            let dbSessions = [];
             if (!sessions) dbSessions = await dbTransaction(
                 hasLocalConfig
-                    ? 'SELECT * FROM sessions WHERE exported IS NOT ? OR local_export IS NOT ?;'
-                    : 'SELECT * FROM sessions WHERE exported IS NOT ?;',
-                hasLocalConfig ? [true, true] : [true]
+                    ? `SELECT * FROM sessions WHERE json_extract(data, '$.completed_at') IS NOT NULL AND json_extract(data, '$.canceled_at') IS NULL AND (exported IS NOT ? OR poll_exported IS NOT ? OR (local_export IS NOT ? AND json_extract(data, '$.country') = ? AND json_extract(data, '$.hospital_id') = ?));`
+                    : `SELECT * FROM sessions WHERE json_extract(data, '$.completed_at') IS NOT NULL AND json_extract(data, '$.canceled_at') IS NULL AND (exported IS NOT ? OR poll_exported IS NOT ?);`,
+                hasLocalConfig ? [true, true, true, currentCountry, currentHospital] : [true, true]
             );
 
-
-            const promises: Promise<any>[] = [];
-            const exportableDbSessions = dbSessions.map(s => ({ ...s, data: JSON.parse(s.data || '{}'), })).filter(s => s.data.completed_at || s.data.canceled_at);
-            const exportData: any[] = sessions || exportableDbSessions.filter(s => s.data.completed_at && !s.exported);
-
-            const failed: any[] = [];
-
-            if (exportData.length) {
-                const postData: any = await convertSessionsToExportable(exportData);
+            const exportableDbSessions = dbSessions
+                .map(s => ({ ...s, data: JSON.parse(s.data || '{}'), }))
+                .filter(isExportableSession);
            
-                postData.forEach((s: any, i: any) => promises.push(new Promise((resolve, reject) => {
-                    (async () => {
-                        try {
-                            const { id, exported,local_export, ...exportable } = s
-  
-                            if(!exported){
-                              
-                            const res = await makeApiCall('nodeapi', `/sessions?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
-                                method: 'POST',
-                                body: JSON.stringify(exportable),
-                            });
-                            
-                            if (res?.status == 200) {
-                                await updateSession({ exported: true }, { where: { id, }, });
-                                resolve(true);
-                            } else {
-                                failed.push(id);
-                                throw new Error('Failed to export session, try again!');
-                            }
-                        }
-                        } catch (e) { 
-                            failed.push(exportData[i].id);
-                            console.log(e); 
-                            reject(e); 
-                        }
-                    })();
-                })));
-            }
-            // Handle /local calls (only if hasLocalConfig)
-            if (exportData.length && hasLocalConfig) {
-                const localData: any = await convertSessionsToExportable(exportData, { showConfidential: true, });
+            const suppliedSessions = sessions ? sessions.filter(isExportableSession) : null;
+            const exportData: any[] = suppliedSessions || exportableDbSessions.filter(
+                s => isExportableSession(s) && (
+                    !s.exported ||
+                    !s.poll_exported ||
+                    (hasLocalConfig && !s.local_export && s.data?.country === currentCountry && s.data?.hospital_id === currentHospital)
+                )
+            );
 
-                localData.forEach((s: any) => promises.push(new Promise((resolve, reject) => {
-                    (async () => {
-                        try {
-                            const { id, exported, local_export, ...exportable } = s
-                            if(!local_export){
-                                const res = await makeLocalApiCall(`/local?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
-                                    method: 'POST',
-                                    body: JSON.stringify(exportable),
-                                })
-                                if (res?.status == 200) {
-                                    await updateSession({ local_export: true }, { where: { id, }, });
-                                }
-                            }
-                            resolve(true);
-                        } catch (ex) {
-                            reject(ex);
-                        }
-                    })();
-                })));
+            if (!exportData.length) {
+                resolve({ ...emptyResult(), localConfigured: hasLocalConfig });
+                return;
             }
 
-            // Handle /save-poll-data calls (for all records)
-            if (exportData.length) {
-                const pollData: any = await convertSessionsToExportable(exportData, { showConfidential: true, });
+            // Yield to the UI before the heavy work below.
+            await afterInteractions();
 
-                pollData.forEach((s: any) => promises.push(new Promise((resolve, reject) => {
-                    (async () => {
-                        try {
-                            const { id, exported, local_export, ...exportable } = s
-                            if(!exported){
-                                await makeApiCall('nodeapi', `/save-poll-data?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
-                                    method: 'POST',
-                                    body: JSON.stringify(exportable),
-                                });
-                            }
-                            resolve(true);
-                        } catch (e) {
-                            reject(e);
-                        }
-                    })();
-                })));
-            }
+            const result = emptyResult();
+            result.localConfigured = hasLocalConfig;
+            const cohorts = groupByCountry(exportData, currentCountry);
 
-            await Promise.all(promises);
+            await Promise.all(Array.from(cohorts.entries()).map(async ([cohortCountry, cohortSessions]) => {
+                const ctx: CohortContext = {
+                    cohortCountry,
+                    cohortSessions,
+                    hasLocalConfig,
+                    location,
+                    result,
+                };
+                try {
+                    await processCountryCohort(ctx);
+                } catch (e) {
+                    markCohortPending(ctx, 'failed', e);
+                }
+            }));
 
-            if (failed.length) throw new Error('Failed to export session, try again!');
-
-            resolve(null);
+            resolve(result);
         } catch (e) {
             reject(e);
         }
@@ -117,3 +318,65 @@ const doExportSessions = (sessions?: any[]) => new Promise((resolve, reject) => 
 });
 
 export const exportSessions = (sessions?: any[]) => withExportLock(() => doExportSessions(sessions));
+
+onCircuitCooldownExpired(() => scheduleExportSessions());
+
+// --- Debounced background export -----------------------------------------------
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let exporting = false;
+let pendingTrailing = false;
+
+const RETRY_BASE_MS = 15_000;
+const RETRY_MAX_MS = 5 * 60_000;
+const RETRY_JITTER_RATIO = 0.2;
+let retryAttempt = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleRetry() {
+    if (retryTimer) return; // one bounded timer at a time
+    const raw = Math.min(RETRY_BASE_MS * (2 ** retryAttempt), RETRY_MAX_MS);
+    const jitter = raw * RETRY_JITTER_RATIO * (Math.random() * 2 - 1);
+    const delay = Math.max(RETRY_BASE_MS, Math.round(raw + jitter));
+    retryAttempt += 1;
+    retryTimer = setTimeout(() => {
+        retryTimer = null;
+        scheduleExportSessions();
+    }, delay);
+}
+
+function clearRetry() {
+    if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+    }
+    retryAttempt = 0;
+}
+
+
+export function scheduleExportSessions() {
+    if (exporting) {
+        pendingTrailing = true;
+        return;
+    }
+    if (debounceTimer) return;
+    debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        exporting = true;
+        exportSessions()
+            .then(result => {
+                const hasPending = result.failedMain.length || result.failedPoll.length || result.failedLocal.length;
+                if (hasPending) scheduleRetry();
+                else clearRetry();
+            })
+            .catch(() => {
+                scheduleRetry();
+            })
+            .finally(() => {
+                exporting = false;
+                if (pendingTrailing) {
+                    pendingTrailing = false;
+                    scheduleExportSessions();
+                }
+            });
+    }, 1500);
+}

--- a/src/data/getConvertedSession.ts
+++ b/src/data/getConvertedSession.ts
@@ -156,6 +156,7 @@ export function formatExportableSession(session: any = {}, opts: any = {}) {
           id: session?.id,
           exported:session.exported,
           local_export:session.local_export,
+          poll_exported:session.poll_exported,
           uid: session.uid,
           unique_key,
           appVersion: APP_VERSION,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -24,3 +24,5 @@ export * from './sessions';
 
 export * from './socket';
 
+export * from './circuitBreaker';
+

--- a/src/data/queries.ts
+++ b/src/data/queries.ts
@@ -8,10 +8,22 @@ export async function getAuthenticatedUser() {
     return user?.details ? JSON.parse(user.details) : null;
 }
 
+let _locationCache: { value: null | types.Location; expires: number } | null = null;
+const LOCATION_CACHE_TTL = 5000;
+
+export function invalidateLocationCache() {
+    _locationCache = null;
+}
+
 export async function getLocation() {
+    if (_locationCache && Date.now() < _locationCache.expires) {
+        return _locationCache.value;
+    }
     const rows = await dbTransaction('select * from location limit 1;', null);
-    return rows[0] as (null | types.Location);
-} 
+    const value = (rows[0] as (null | types.Location)) ?? null;
+    _locationCache = { value, expires: Date.now() + LOCATION_CACHE_TTL };
+    return value;
+}
 
 export const getApplication = () => new Promise<types.Application>((resolve, reject) => {
     (async () => {

--- a/src/data/saveSession.ts
+++ b/src/data/saveSession.ts
@@ -1,33 +1,47 @@
 import { dbTransaction } from './db';
 import { makeApiCall } from './api';
-import { exportSessions } from './exportSessions';
+import { scheduleExportSessions } from './exportSessions';
 
 export const saveSession = (data: any = {}) => new Promise<any>((resolve, reject) => {
 (async () => {
-    const columns = [data.id ? 'id' : '', 'uid', 'script_id', 'data', 'completed', 'exported', 'createdAt', 'updatedAt']
-        .filter(c => c)
-        .join(',');
-
-    const values = [data.id ? '?' : '', '?', '?', '?', '?', '?', '?', '?']
-        .filter(c => c)
-        .join(',');
-
-    const params = [
-        ...data.id ? [data.id] : [],
-        data.uid,
-        data.script_id,
-        JSON.stringify({ ...data?.data, }),
-        data.completed || false,
-        data.exported || false,
-        data.createdAt || new Date().toISOString(),
-        data.updatedAt || new Date().toISOString(),
-    ];
-
 	let sessionID = null;
 
     let application = null;
     try {
-		const res = await dbTransaction(`insert or replace into sessions (${columns}) values (${values}) RETURNING id;`, params);
+        let payloadData = { ...data?.data };
+        if (data.id) {
+            const existingRows = await dbTransaction('select data from sessions where id=?;', [data.id]);
+            const existingKey = (() => {
+                try { return JSON.parse(existingRows?.[0]?.data || '{}')?.unique_key; }
+                catch { return undefined; }
+            })();
+            if (existingKey) payloadData = { ...payloadData, unique_key: existingKey };
+        }
+
+        const res = data.id
+            ? await dbTransaction(
+                `UPDATE sessions SET uid=?, script_id=?, data=?, completed=?, updatedAt=? WHERE id=? RETURNING id;`,
+                [
+                    data.uid,
+                    data.script_id,
+                    JSON.stringify(payloadData),
+                    data.completed || false,
+                    data.updatedAt || new Date().toISOString(),
+                    data.id,
+                ]
+            )
+            : await dbTransaction(
+                `insert into sessions (uid, script_id, data, completed, exported, createdAt, updatedAt) values (?, ?, ?, ?, ?, ?, ?) RETURNING id;`,
+                [
+                    data.uid,
+                    data.script_id,
+                    JSON.stringify(payloadData),
+                    data.completed || false,
+                    data.exported || false,
+                    data.createdAt || new Date().toISOString(),
+                    data.updatedAt || new Date().toISOString(),
+                ]
+            );
 
         if (!res[0]) throw new Error('Failed to save session');
 
@@ -61,8 +75,9 @@ export const saveSession = (data: any = {}) => new Promise<any>((resolve, reject
                  
             });
         }
-		exportSessions().then(() => {}).catch(() => {}); // this will export sessions that haven't yet been exported
-		
+
+		scheduleExportSessions();
+
 		resolve({ application, sessionID });
     } catch (e) { console.log('saveSession', e); reject(e); /* DO NOTHING */ }
 })();

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -4,6 +4,10 @@ import { convertSessionsToExportable } from './convertSessionsToExportable';
 
 
 export const exportSession = async (s: any) => {
+    if (!s?.completed_at || s?.canceled_at) {
+        throw new Error('Only completed sessions can be exported');
+    }
+
     try {
         const res = await makeApiCall('nodeapi', `/sessions?uid=${s.uid}&scriptId=${s.script.id}&unique_key=${s.unique_key}`, {
             method: 'POST',

--- a/src/data/socket.ts
+++ b/src/data/socket.ts
@@ -3,60 +3,78 @@ import io from 'socket.io-client';
 import { COUNTRY } from '../types';
 import { getExportedSessions } from './sessions';
 import { getLocation } from './queries';
+import { resetCircuit, backendKey } from './circuitBreaker';
+import { scheduleExportSessions } from './exportSessions';
 import { APP_CONFIG } from '../constants';
 
 
 const countries = (APP_CONFIG.countries || []) as COUNTRY[];
+
+const SOCKET_OPTS = {
+  reconnectionDelay: 2000,
+  reconnectionDelayMax: 30000,
+  timeout: 15000,
+};
 
 export const sockets: { [key: string]: any; } = countries.reduce((acc, country) => {
   const webEditorHost = APP_CONFIG[country?.iso]?.webeditor.host || null;
   const nodeApiHost = APP_CONFIG[country?.iso]?.nodeapi.host || null;
   return {
     ...acc,
-    ...(webEditorHost ? { [`${country}WebEditor`]: io(webEditorHost) } : null),
-    ...(nodeApiHost ? { [`${country}NodeApi`]: io(nodeApiHost) } : null),
+    ...(webEditorHost ? { [`${country.iso}WebEditor`]: io(webEditorHost, SOCKET_OPTS) } : null),
+    ...(nodeApiHost ? { [`${country.iso}NodeApi`]: io(nodeApiHost, SOCKET_OPTS) } : null),
   };
 }, {});
 
-export async function addSocketEventsListeners(listener: (e: any) => void) {
+const noop = () => {};
+
+export async function addSocketEventsListeners(listener: (e: any) => void): Promise<() => void> {
     try {
         const loc = await getLocation();
         const country = loc?.country;
 
-        if (country) {
-            const onEvent = (e: any) => setTimeout(() => listener && listener(e), 0);
+        if (!country) return noop;
 
-            const webeditorSocket = sockets[`${country}WebEditor`];
-            const nodeApiSocket = sockets[`${country}NodeApi`];
+        const onEvent = (e: any) => setTimeout(() => listener && listener(e), 0);
 
-            if (webeditorSocket) {
-                webeditorSocket.on('data_updated', (data: any) => onEvent({
-                    name: 'data_updated',
-                    ...data
-                }));
+        const webeditorSocket = sockets[`${country}WebEditor`];
+        const nodeApiSocket = sockets[`${country}NodeApi`];
 
-                webeditorSocket.on('data_published', (data: any) => onEvent({
-                    name: 'data_published',
-                    ...data
-                }));
-
-                webeditorSocket.on('changes_discarded', (data: any) => onEvent({
-                    name: 'changes_discarded',
-                    ...data
-                }));
-            }
-
-            if (nodeApiSocket) {
-                nodeApiSocket.on('sessions_exported', (data: any) => {
-                    getExportedSessions().then(() => {}).catch(() => {}); // these will load all the exported sessions that are not on this device
-                    onEvent({
-                    name: 'sessions_exported',
-                    ...data
-                    });
-                });
-            }
-        }
-    } catch(e) { 
         
-        /**/ }
+        const onWebeditorConnect = () => resetCircuit(backendKey(country, 'webeditor'));
+        const onNodeApiConnect = () => {
+            resetCircuit(backendKey(country, 'nodeapi'));
+            scheduleExportSessions();
+        };
+        const onDataUpdated = (data: any) => onEvent({ name: 'data_updated', ...data });
+        const onDataPublished = (data: any) => onEvent({ name: 'data_published', ...data });
+        const onChangesDiscarded = (data: any) => onEvent({ name: 'changes_discarded', ...data });
+        const onSessionsExported = (data: any) => {
+            getExportedSessions().then(() => {}).catch(() => {}); // these will load all the exported sessions that are not on this device
+            onEvent({ name: 'sessions_exported', ...data });
+        };
+
+        if (webeditorSocket) {
+            webeditorSocket.on('connect', onWebeditorConnect);
+            webeditorSocket.on('data_updated', onDataUpdated);
+            webeditorSocket.on('data_published', onDataPublished);
+            webeditorSocket.on('changes_discarded', onChangesDiscarded);
+        }
+
+        if (nodeApiSocket) {
+            nodeApiSocket.on('connect', onNodeApiConnect);
+            nodeApiSocket.on('sessions_exported', onSessionsExported);
+        }
+
+        return () => {
+            webeditorSocket?.off('connect', onWebeditorConnect);
+            webeditorSocket?.off('data_updated', onDataUpdated);
+            webeditorSocket?.off('data_published', onDataPublished);
+            webeditorSocket?.off('changes_discarded', onChangesDiscarded);
+            nodeApiSocket?.off('connect', onNodeApiConnect);
+            nodeApiSocket?.off('sessions_exported', onSessionsExported);
+        };
+    } catch(e) {
+        return noop;
+    }
 }

--- a/src/data/syncData.ts
+++ b/src/data/syncData.ts
@@ -5,17 +5,16 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { APP_VERSION } from '@/src/constants';
 import { getDeviceID } from '@/src/utils/getDeviceID';
-import { createTablesIfNotExist, dbTransaction,addNewColumns } from './db';
-import { makeApiCall, reportErrors } from './api';
+import { dbTransaction, ensureSchema, db } from './db';
+import { makeApiCall, reportErrors, SYNC_DOWNLOAD_TIMEOUT_MS, REMOTE_PROBE_TIMEOUT_MS } from './api';
 import { getApplication, getAuthenticatedUser, getExceptions, getLocation } from './queries';
 import { ASYNC_STORAGE_KEYS } from '../constants/async-storage';
 
-export async function syncData(opts?: { force?: boolean; }) {  
+export async function syncData(opts?: { force?: boolean; }) {
 	const netInfo = await NetInfo.fetch();
-    // const networkState = await Network.getNetworkStateAsync(); 
+    // const networkState = await Network.getNetworkStateAsync();
 
-    await createTablesIfNotExist();
-    await addNewColumns();
+    await ensureSchema();
 
     await AsyncStorage.removeItem(ASYNC_STORAGE_KEYS.SYNC_ERROR);
 
@@ -25,21 +24,41 @@ export async function syncData(opts?: { force?: boolean; }) {
 
     let last_sync_date = null;
 
+    const knownOffline = netInfo?.isConnected === false || netInfo?.isInternetReachable === false;
+    const shouldAttempt = Boolean(authenticatedUser) && !knownOffline;
+
+    if (opts?.force && !shouldAttempt) {
+        await AsyncStorage.setItem(ASYNC_STORAGE_KEYS.SYNC_ERROR, 'Failed to connect to sync');
+        throw new Error(
+            authenticatedUser
+                ? 'No internet connection. Connect to a network and try again.'
+                : 'You must be signed in to sync.'
+        );
+    }
+
 	// if (authenticatedUser && networkState?.isConnected && networkState?.isInternetReachable) {
-    if (authenticatedUser && netInfo?.isConnected && netInfo?.isInternetReachable) {
+    if (shouldAttempt) {
         const app = await getApplication();
 
         last_sync_date = app?.last_sync_date;
 
         let webUpdated = false;
         let versionUpdated = false;
+        let probeSucceeded = false;
 
         try {
-            const deviceReg = await makeApiCall('webeditor', `/get-device-registration?deviceId=${deviceId}`);
+            const deviceReg = await makeApiCall(
+                'webeditor',
+                `/get-device-registration?deviceId=${deviceId}`,
+                undefined,
+                { timeout: REMOTE_PROBE_TIMEOUT_MS },
+            );
+            if (!deviceReg.ok) throw new Error(`get-device-registration failed with status ${deviceReg.status}`);
             const deviceRegJSON = await deviceReg.json();
-          
-            webUpdated = deviceRegJSON?.info?.last_backup_date && 
-                last_sync_date && 
+            probeSucceeded = true;
+
+            webUpdated = deviceRegJSON?.info?.last_backup_date &&
+                last_sync_date &&
                 (new Date(deviceRegJSON?.info?.last_backup_date).getTime() !== new Date(last_sync_date).getTime());
 
             last_sync_date = deviceRegJSON?.info?.last_backup_date;
@@ -50,9 +69,11 @@ export async function syncData(opts?: { force?: boolean; }) {
             AsyncStorage.setItem(ASYNC_STORAGE_KEYS.SYNC_ERROR, 'Failed to connect to sync');
         }
 
-        let shouldSync = opts?.force || versionUpdated || webUpdated;
+        let shouldSync = probeSucceeded && (opts?.force || versionUpdated || webUpdated);
 
-        // shouldSync = true;
+        if (opts?.force && !probeSucceeded) {
+            throw new Error('Failed to connect to sync');
+        }
 
         if (shouldSync) {
             try{
@@ -63,122 +84,32 @@ export async function syncData(opts?: { force?: boolean; }) {
                 const res = await makeApiCall(
                     'webeditor',
                     `/sync-data?${queryString.stringify({ deviceId, hospitalId: location?.hospital, })}`,
+                    undefined,
+                    { timeout: SYNC_DOWNLOAD_TIMEOUT_MS },
                 );
+
+                if (!res.ok) throw new Error(`sync-data request failed with status ${res.status}`);
                 const json = await res.json();
-                const webeditorInfo = json?.webeditorInfo || {};
-                const device = json?.device || {};
-                const configKeys = json?.configKeys || [];
-                const drugsLibrary = json?.drugsLibrary || [];
-                const scripts = json?.scripts || [];
-                const screens = json?.screens || [];
-                const diagnoses = json?.diagnoses || [];
-                const problems = json?.problems || [];
-                const aliases = json?.aliases || []
-                
-                await Promise.all(['scripts', 'screens', 'diagnoses', 'problems', 'config_keys', 'drugs_library'].map(table => dbTransaction(
-                    `delete from ${table} where 1;`
-                )));
 
-                const promises: Promise<any>[] = [];
+                const requiredKeys = ['webeditorInfo', 'device', 'configKeys', 'drugsLibrary', 'scripts', 'screens', 'diagnoses', 'problems'];
+                const hasValidShape = json && typeof json === 'object' && !Array.isArray(json)
+                    && requiredKeys.every(key => key in json);
+                if (!hasValidShape) throw new Error('sync-data response has an unexpected shape');
 
-                configKeys.map((s: any) => {
-                    const columns = ['id', 'config_key_id', 'data', 'createdAt', 'updatedAt'].join(',');
-                    const values = ['?', '?', '?', '?', '?'].join(',');
-                    return dbTransaction(`insert or replace into config_keys (${columns}) values (${values});`, [
-                        s.id,
-                        s.config_key_id,
-                        JSON.stringify(s.data || {}),
-                        s.createdAt,
-                        s.updatedAt
-                    ]);
-                });
-
-                drugsLibrary.map((s: any) => {
-                    const columns = ['id', 'item_id', 'data', 'createdAt', 'updatedAt'].join(',');
-                    const values = ['?', '?', '?', '?', '?'].join(',');
-                    return dbTransaction(`insert or replace into drugs_library (${columns}) values (${values});`, [
-                        s.id,
-                        s.itemId,
-                        JSON.stringify(s || {}),
-                        s.createdAt,
-                        s.updatedAt
-                    ]);
-                });
-
-                scripts.map((s: any) => {
-                    s.data = { ...s.data };
-                    const columns = ['id', 'script_id', 'type', 'data', 'position', 'createdAt', 'updatedAt'].join(',');
-                    const values = ['?', '?', '?', '?', '?', '?', '?'].join(',');
-                    promises.push(dbTransaction(`insert or replace into scripts (${columns}) values (${values});`, [
-                        s.id,
-                        s.script_id,
-                        s.type || s.data.type,
-                        JSON.stringify(s.data),
-                        s.position,
-                        s.createdAt,
-                        s.updatedAt
-                    ]));
-                });
-                    aliases?.data?.map((s: any) => {
-                    const columns = ['scriptid', 'old_script', 'alias', 'name'].join(',');
-                    const values = ['?', '?', '?', '?'].join(',');
-                    promises.push(dbTransaction(`insert or replace into nt_aliases (${columns}) values (${values});`, [
-                        s.script,
-                        s.oldScript,
-                        s.alias,
-                        s.name
-                    ]));
-                });
-
-                screens.map((s: any) => {
-                    const columns = ['id', 'screen_id', 'script_id', 'position', 'type', 'data', 'createdAt', 'updatedAt'].join(',');
-                    const values = ['?', '?', '?', '?', '?', '?', '?', '?'].join(',');
-                    promises.push(dbTransaction(`insert or replace into screens (${columns}) values (${values});`, [
-                        s.id,
-                        s.screen_id,
-                        s.script_id,
-                        s.position,
-                        s.type,
-                        JSON.stringify(s.data || {}),
-                        s.createdAt,
-                        s.updatedAt
-                    ]));
-                });
-
-                diagnoses.map((s: any) => {
-                    const columns = ['id', 'diagnosis_id', 'script_id', 'position', 'type', 'data', 'createdAt', 'updatedAt'].join(',');
-                    const values = ['?', '?', '?', '?', '?', '?', '?', '?'].join(',');
-                    promises.push(dbTransaction(`insert or replace into diagnoses (${columns}) values (${values});`, [
-                        s.id,
-                        s.diagnosis_id,
-                        s.script_id,
-                        s.position,
-                        s.type,
-                        JSON.stringify(s.data || {}),
-                        s.createdAt,
-                        s.updatedAt
-                    ]));
-                });
-
-                problems.map((s: any) => {
-                    const columns = ['id', 'problem_id', 'script_id', 'position', 'type', 'data', 'createdAt', 'updatedAt'].join(',');
-                    const values = ['?', '?', '?', '?', '?', '?', '?', '?'].join(',');
-                    promises.push(dbTransaction(`insert or replace into problems (${columns}) values (${values});`, [
-                        s.id,
-                        s.problem_id,
-                        s.script_id,
-                        s.position,
-                        s.type,
-                        JSON.stringify(s.data || {}),
-                        s.createdAt,
-                        s.updatedAt
-                    ]));
-                });
+                const webeditorInfo = json.webeditorInfo || {};
+                const device = json.device || {};
+                const configKeys = json.configKeys || [];
+                const drugsLibrary = json.drugsLibrary || [];
+                const scripts = json.scripts || [];
+                const screens = json.screens || [];
+                const diagnoses = json.diagnoses || [];
+                const problems = json.problems || [];
+                const aliasesData = Array.isArray(json.aliases?.data) ? json.aliases.data : null;
 
                 const getApplicationRslt = await dbTransaction('select * from application where id=1;');
                 const _application = getApplicationRslt[0];
 
-                let application = {
+                const application = {
                     id: 1,
                     mode: _application?.mode || 'production',
                     last_sync_date,
@@ -186,18 +117,125 @@ export async function syncData(opts?: { force?: boolean; }) {
                     total_sessions_recorded: Math.max(_application?.total_sessions_recorded || 0, device?.details?.scripts_count || 0),
                     device_id: _application?.device_id || device?.device_id || deviceId,
                     webeditor_info: JSON.stringify(webeditorInfo),
-                    createdAt: _application?.createdAt || new Date().toISOString(),            
+                    createdAt: _application?.createdAt || new Date().toISOString(),
                     version: APP_VERSION,
                     updatedAt: new Date().toISOString(),
                 };
 
+                // Replace-everything is all-or-nothing: if any part of the bulk download/validation/transaction fails, the local db is left unchanged. The exclusive transaction below ensures that no other db operations can interleave with this one.
+                await db.withExclusiveTransactionAsync(async (txn: any) => {
+                    const tablesToReplace = ['scripts', 'screens', 'diagnoses', 'problems', 'config_keys', 'drugs_library'];
 
-                await dbTransaction(
-                    `insert or replace into application (${Object.keys(application).join(',')}) values (${Object.keys(application).map(() => '?').join(',')});`,
-                    Object.values(application)
-                );
+                    if (aliasesData) tablesToReplace.push('nt_aliases');
+                    await Promise.all(tablesToReplace.map(table => dbTransaction(
+                        `delete from ${table} where 1;`, null, undefined, txn
+                    )));
 
-                await Promise.all(promises);
+                    const writes: Promise<any>[] = [];
+
+                    configKeys.forEach((s: any) => {
+                        const columns = ['id', 'config_key_id', 'data', 'createdAt', 'updatedAt'].join(',');
+                        const values = ['?', '?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into config_keys (${columns}) values (${values});`, [
+                            s.id,
+                            s.config_key_id,
+                            JSON.stringify(s.data || {}),
+                            s.createdAt,
+                            s.updatedAt
+                        ], undefined, txn));
+                    });
+
+                    drugsLibrary.forEach((s: any) => {
+                        const columns = ['id', 'item_id', 'data', 'createdAt', 'updatedAt'].join(',');
+                        const values = ['?', '?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into drugs_library (${columns}) values (${values});`, [
+                            s.id,
+                            s.itemId,
+                            JSON.stringify(s || {}),
+                            s.createdAt,
+                            s.updatedAt
+                        ], undefined, txn));
+                    });
+
+                    scripts.forEach((s: any) => {
+                        s.data = { ...s.data };
+                        const columns = ['id', 'script_id', 'type', 'data', 'position', 'createdAt', 'updatedAt'].join(',');
+                        const values = ['?', '?', '?', '?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into scripts (${columns}) values (${values});`, [
+                            s.id,
+                            s.script_id,
+                            s.type || s.data.type,
+                            JSON.stringify(s.data),
+                            s.position,
+                            s.createdAt,
+                            s.updatedAt
+                        ], undefined, txn));
+                    });
+                    (aliasesData || []).forEach((s: any) => {
+                        const columns = ['scriptid', 'old_script', 'alias', 'name'].join(',');
+                        const values = ['?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into nt_aliases (${columns}) values (${values});`, [
+                            s.script,
+                            s.oldScript,
+                            s.alias,
+                            s.name
+                        ], undefined, txn));
+                    });
+
+                    screens.forEach((s: any) => {
+                        const columns = ['id', 'screen_id', 'script_id', 'position', 'type', 'data', 'createdAt', 'updatedAt'].join(',');
+                        const values = ['?', '?', '?', '?', '?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into screens (${columns}) values (${values});`, [
+                            s.id,
+                            s.screen_id,
+                            s.script_id,
+                            s.position,
+                            s.type,
+                            JSON.stringify(s.data || {}),
+                            s.createdAt,
+                            s.updatedAt
+                        ], undefined, txn));
+                    });
+
+                    diagnoses.forEach((s: any) => {
+                        const columns = ['id', 'diagnosis_id', 'script_id', 'position', 'type', 'data', 'createdAt', 'updatedAt'].join(',');
+                        const values = ['?', '?', '?', '?', '?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into diagnoses (${columns}) values (${values});`, [
+                            s.id,
+                            s.diagnosis_id,
+                            s.script_id,
+                            s.position,
+                            s.type,
+                            JSON.stringify(s.data || {}),
+                            s.createdAt,
+                            s.updatedAt
+                        ], undefined, txn));
+                    });
+
+                    problems.forEach((s: any) => {
+                        const columns = ['id', 'problem_id', 'script_id', 'position', 'type', 'data', 'createdAt', 'updatedAt'].join(',');
+                        const values = ['?', '?', '?', '?', '?', '?', '?', '?'].join(',');
+                        writes.push(dbTransaction(`insert or replace into problems (${columns}) values (${values});`, [
+                            s.id,
+                            s.problem_id,
+                            s.script_id,
+                            s.position,
+                            s.type,
+                            JSON.stringify(s.data || {}),
+                            s.createdAt,
+                            s.updatedAt
+                        ], undefined, txn));
+                    });
+
+                    await Promise.all(writes);
+
+                    await dbTransaction(
+                        `insert or replace into application (${Object.keys(application).join(',')}) values (${Object.keys(application).map(() => '?').join(',')});`,
+                        Object.values(application),
+                        undefined,
+                        txn
+                    );
+                });
 
                 const exeptions = await getExceptions();
                 if(exeptions){
@@ -215,25 +253,26 @@ export async function syncData(opts?: { force?: boolean; }) {
                                 `insert or replace into exceptions (${Object.keys(ex).join(',')}) values (${Object.keys(ex).map(() => '?').join(',')});`,
                                 Object.values(ex)
                             );
-                
+
                         }).catch(() => {})
-                    
+
                     }
                 }
             } catch(e: any) {
                 console.log('syncData', e)
                 reportErrors('syncData', e.message);
-                if (!app?.webeditor_info?.version) throw new Error(e);
                 AsyncStorage.setItem(ASYNC_STORAGE_KEYS.SYNC_ERROR, 'Failed to connect to sync');
+
+                if (opts?.force || !app?.webeditor_info?.version) throw new Error(e);
             }
         }
     }
 
     const _app = await getApplication();
 
-    return { 
-        authenticatedUser, 
+    return {
+        authenticatedUser,
         application: _app,
         last_sync_date,
     };
-}  
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,28 +17,42 @@ export * from './components';
 
 export function Navigation() {
     const [ready, setReady] = React.useState(false);
-    const {setSyncDataResponse,authenticatedUser} = useAppContext()||{};
+    const {setSyncDataResponse,authenticatedUser,locationVersion} = useAppContext()||{};
 
     const initialiseApp = React.useCallback(async () => {
-        try { 
-            const res = await syncData(); 
-            if(setSyncDataResponse)          
+        try {
+            const res = await syncData();
+            if(setSyncDataResponse)
                 setSyncDataResponse(res);
         } catch (e) {
             console.log(e);
         } finally {
             setReady(true);
-        } 
+        }
     }, [setSyncDataResponse]);
 
     React.useEffect(() => { if (!ready) initialiseApp(); }, [ready]);
 
+    // Registered once: NetInfo transitions and circuit resets aren't tied to location.
     React.useEffect(() => {
-        addSocketEventsListeners(initialiseApp);
         const unsubscribe = registerExportOnReconnect();
         return unsubscribe;
     }, []);
-      
+
+    React.useEffect(() => {
+        let cancelled = false;
+        let cleanup: (() => void) | undefined;
+
+        addSocketEventsListeners(initialiseApp).then(unsubscribe => {
+            if (cancelled) { unsubscribe(); return; }
+            cleanup = unsubscribe;
+        });
+
+        return () => {
+            cancelled = true;
+            cleanup?.();
+        };
+    }, [locationVersion]);
 
     if (!ready) return <Splash />;
 


### PR DESCRIPTION
## Ticket: [NEOAPP1412](https://neotree.atlassian.net/browse/NEOAPP-1412)
The current offline-first implementation only checks network connectivity and does not account for backend server availability. When the device has internet access but the backend is down or unreachable, the app continues attempting remote API calls instead of falling back to offline behaviour.

This results in hanging export requests, blocked local exports due to the shared export queue, and progressively slower performance as the unexported session backlog grows. The app should distinguish between network offline and backend unavailable, allowing offline workflows to continue seamlessly when the server is unreachable.

## Summary

Makes session export genuinely resilient when either backend is unavailable, and stops the app from destroying or misreporting clinical data that hasn't reached a server yet.

Adds a new per-backend circuit breaker (`src/data/circuitBreaker.ts`) so a dead backend fails fast instead of hanging, without ever blocking a healthy one.